### PR TITLE
fix: deterministic headless recording, lossless capture, and compositor optimizations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,8 @@ coverage
 *.log
 package-lock.json
 demo-reel.mp4
+
+.idea/
+.pi/
+videos/
+webreel.config.json

--- a/packages/@webreel/core/src/compositor.ts
+++ b/packages/@webreel/core/src/compositor.ts
@@ -5,7 +5,7 @@ import { resolve, extname } from "node:path";
 import sharp from "sharp";
 import type { TimelineData } from "./timeline.js";
 import { ensureFfmpeg } from "./ffmpeg.js";
-import { finalizeMp4, finalizeWebm, finalizeGif, type SfxConfig } from "./media.js";
+import { finalizeMp4, finalizeWebm, type SfxConfig } from "./media.js";
 
 interface OverlayContext {
   cursorPng: Buffer;
@@ -40,22 +40,36 @@ export async function compose(
     zoom,
   );
 
-  const workDir = resolve(homedir(), ".webreel");
-  mkdirSync(workDir, { recursive: true });
-  const tempComposed = resolve(workDir, `_composed_${Date.now()}.mp4`);
+  const ext = extname(outputPath).toLowerCase();
 
-  try {
+  if (ext === ".gif") {
+    const gifConfig = buildGifConfig(timelineData.width, outputPath);
     await compositeFrames(
       ffmpegPath,
       cleanVideoPath,
       timelineData,
       cursorPng,
       zoom,
-      tempComposed,
-      crf,
+      gifConfig,
+    );
+    return;
+  }
+
+  const workDir = resolve(homedir(), ".webreel");
+  mkdirSync(workDir, { recursive: true });
+  const tempComposed = resolve(workDir, `_composed_${Date.now()}.mp4`);
+
+  try {
+    const mp4Config = buildMp4Config(timelineData.fps, crf, tempComposed);
+    await compositeFrames(
+      ffmpegPath,
+      cleanVideoPath,
+      timelineData,
+      cursorPng,
+      zoom,
+      mp4Config,
     );
 
-    const ext = extname(outputPath).toLowerCase();
     const durationSec = timelineData.frames.length / timelineData.fps;
 
     if (ext === ".webm") {
@@ -67,8 +81,6 @@ export async function compose(
         durationSec,
         sfx,
       );
-    } else if (ext === ".gif") {
-      finalizeGif(ffmpegPath, tempComposed, outputPath, timelineData.width);
     } else {
       finalizeMp4(
         ffmpegPath,
@@ -97,33 +109,19 @@ async function renderCursorPng(
   return sharp(Buffer.from(svgWithSize)).png().toBuffer();
 }
 
-async function compositeFrames(
-  ffmpegPath: string,
-  cleanVideoPath: string,
-  timeline: TimelineData,
-  cursorPng: Buffer,
-  zoom: number,
-  outputPath: string,
-  crf: number,
-): Promise<void> {
-  const { width, height, fps } = timeline;
+interface CompositorFfmpegConfig {
+  filterComplex: string;
+  outputArgs: string[];
+}
 
-  const ffmpeg = spawn(
-    ffmpegPath,
-    [
-      "-y",
-      "-i",
-      cleanVideoPath,
-      "-f",
-      "image2pipe",
-      "-framerate",
-      String(fps),
-      "-c:v",
-      "png",
-      "-i",
-      "pipe:0",
-      "-filter_complex",
-      "[0][1]overlay=0:0:shortest=1",
+function buildMp4Config(
+  fps: number,
+  crf: number,
+  outputPath: string,
+): CompositorFfmpegConfig {
+  return {
+    filterComplex: "[0][1]overlay=0:0:shortest=1",
+    outputArgs: [
       "-c:v",
       "libx264",
       "-preset",
@@ -143,6 +141,52 @@ async function compositeFrames(
       "-r",
       String(fps),
       outputPath,
+    ],
+  };
+}
+
+const GIF_FPS = 15;
+const GIF_BAYER_SCALE = 5;
+
+function buildGifConfig(width: number, outputPath: string): CompositorFfmpegConfig {
+  return {
+    filterComplex: [
+      `[0][1]overlay=0:0:shortest=1`,
+      `fps=${GIF_FPS}`,
+      `scale=${width}:-1:flags=lanczos`,
+      `split[s0][s1];[s0]palettegen=stats_mode=full[p];[s1][p]paletteuse=dither=bayer:bayer_scale=${GIF_BAYER_SCALE}`,
+    ].join(","),
+    outputArgs: ["-loop", "0", outputPath],
+  };
+}
+
+async function compositeFrames(
+  ffmpegPath: string,
+  cleanVideoPath: string,
+  timeline: TimelineData,
+  cursorPng: Buffer,
+  zoom: number,
+  config: CompositorFfmpegConfig,
+): Promise<void> {
+  const { width, height, fps } = timeline;
+
+  const ffmpeg = spawn(
+    ffmpegPath,
+    [
+      "-y",
+      "-i",
+      cleanVideoPath,
+      "-f",
+      "image2pipe",
+      "-framerate",
+      String(fps),
+      "-c:v",
+      "png",
+      "-i",
+      "pipe:0",
+      "-filter_complex",
+      config.filterComplex,
+      ...config.outputArgs,
     ],
     { stdio: ["pipe", "pipe", "pipe"] },
   );
@@ -189,29 +233,12 @@ async function compositeFrames(
   const stdin = ffmpeg.stdin;
   if (!stdin) throw new Error("ffmpeg process has no stdin pipe");
 
-  const drain = (): Promise<void> => new Promise((res) => stdin.once("drain", res));
-
-  for (let i = 0; i < timeline.frames.length; i++) {
-    const frame = timeline.frames[i];
-    const overlayPng = await renderOverlayFrame(
-      frame,
-      width,
-      height,
-      ctx,
-      overlayCache,
-      hudCache,
-    );
-
-    const ok = stdin.write(overlayPng);
-    if (!ok) await drain();
-  }
-
-  stdin.end();
-
   const stderrChunks: Buffer[] = [];
   ffmpeg.stderr?.on("data", (chunk: Buffer) => stderrChunks.push(chunk));
 
-  await new Promise<void>((resolveAll, rejectAll) => {
+  // Register close/error listeners immediately to avoid missing events.
+  const KILL_TIMEOUT = 5_000;
+  const ffmpegDone = new Promise<void>((resolveAll, rejectAll) => {
     ffmpeg.on("close", (code) => {
       if (code === 0) {
         resolveAll();
@@ -226,6 +253,114 @@ async function compositeFrames(
     });
     ffmpeg.on("error", rejectAll);
   });
+
+  const PREFETCH_QUEUE_SIZE = 4;
+
+  const state = {
+    abortError: null as Error | null,
+    producerDone: false,
+    // Resolves when the queue has items OR the producer is done.
+    queueResolve: null as (() => void) | null,
+    // Resolves when the consumer dequeues an item (backpressure signal).
+    spaceResolve: null as (() => void) | null,
+  };
+
+  // EPIPE is expected when ffmpeg finishes reading and closes its stdin.
+  stdin.on("error", (err: NodeJS.ErrnoException) => {
+    if (err.code === "EPIPE") return;
+    if (!state.abortError) state.abortError = err;
+  });
+
+  const queue: Buffer[] = [];
+
+  const notifyConsumer = () => {
+    if (state.queueResolve) {
+      const r = state.queueResolve;
+      state.queueResolve = null;
+      r();
+    }
+  };
+
+  const notifyProducer = () => {
+    if (state.spaceResolve) {
+      const r = state.spaceResolve;
+      state.spaceResolve = null;
+      r();
+    }
+  };
+
+  const enqueue = (buf: Buffer) => {
+    queue.push(buf);
+    notifyConsumer();
+  };
+
+  const waitForItem = (): Promise<void> =>
+    new Promise((r) => {
+      if (queue.length > 0 || state.producerDone) return r();
+      state.queueResolve = r;
+    });
+
+  const waitForSpace = (): Promise<void> =>
+    new Promise((r) => {
+      if (queue.length < PREFETCH_QUEUE_SIZE) return r();
+      state.spaceResolve = r;
+    });
+
+  const drain = (): Promise<void> => new Promise((r) => stdin.once("drain", r));
+
+  const consumer = async () => {
+    while (true) {
+      if (queue.length === 0 && state.producerDone) break;
+      if (queue.length === 0) await waitForItem();
+      if (queue.length === 0) break;
+      if (state.abortError) break;
+
+      while (queue.length > 0) {
+        const buf = queue.shift()!;
+        notifyProducer();
+        const ok = stdin.write(buf);
+        if (!ok && !state.abortError) await drain();
+        if (state.abortError) break;
+      }
+    }
+    stdin.end();
+  };
+
+  const consumerPromise = consumer();
+
+  for (let i = 0; i < timeline.frames.length; i++) {
+    if (state.abortError) break;
+
+    const frame = timeline.frames[i];
+    const overlayPng = await renderOverlayFrame(
+      frame,
+      width,
+      height,
+      ctx,
+      overlayCache,
+      hudCache,
+    );
+
+    if (state.abortError) break;
+
+    if (queue.length >= PREFETCH_QUEUE_SIZE) await waitForSpace();
+
+    if (!state.abortError) enqueue(overlayPng);
+  }
+  state.producerDone = true;
+  notifyConsumer();
+
+  await consumerPromise;
+
+  if (state.abortError) {
+    ffmpeg.kill("SIGTERM");
+    setTimeout(() => {
+      if (!ffmpeg.killed) ffmpeg.kill("SIGKILL");
+    }, KILL_TIMEOUT);
+    throw state.abortError;
+  }
+
+  await ffmpegDone;
 }
 
 async function renderOverlayFrame(
@@ -236,8 +371,12 @@ async function renderOverlayFrame(
   cache: Map<string, Buffer>,
   hudCache: Map<string, sharp.OverlayOptions>,
 ): Promise<Buffer> {
-  const cx = Math.round(frame.cursor.x * ctx.zoom * 10) / 10;
-  const cy = Math.round(frame.cursor.y * ctx.zoom * 10) / 10;
+  // Whole-pixel rounding is intentional: sub-pixel precision defeats the
+  // overlay cache during cursor dwell/pause (float jitter creates unique keys).
+  // The 1px difference is imperceptible at screen resolution and invisible
+  // in GIF output (downsampled to 15fps with lanczos).
+  const cx = Math.round(frame.cursor.x * ctx.zoom);
+  const cy = Math.round(frame.cursor.y * ctx.zoom);
   const scale = frame.cursor.scale;
   const hudKey = frame.hud ? frame.hud.labels.join("|") : "";
   const cacheKey = `${cx},${cy},${scale},${hudKey}`;
@@ -247,8 +386,8 @@ async function renderOverlayFrame(
 
   const overlays: sharp.OverlayOptions[] = [];
 
-  const icx = Math.round(frame.cursor.x * ctx.zoom) - ctx.hotspotOffsetX;
-  const icy = Math.round(frame.cursor.y * ctx.zoom) - ctx.hotspotOffsetY;
+  const icx = cx - ctx.hotspotOffsetX;
+  const icy = cy - ctx.hotspotOffsetY;
   const cursorVisible =
     icx >= -ctx.cursorWidth && icx < width && icy >= -ctx.cursorHeight && icy < height;
 

--- a/packages/@webreel/core/src/recorder.ts
+++ b/packages/@webreel/core/src/recorder.ts
@@ -91,7 +91,7 @@ export class Recorder {
         "-framerate",
         String(this.fps),
         "-c:v",
-        "mjpeg",
+        "png",
         "-i",
         "pipe:0",
         "-c:v",
@@ -159,7 +159,6 @@ export class Recorder {
   }
 
   private async captureLoop(client: CDPClient) {
-    let lastFrameTime = Date.now();
     let consecutiveErrors = 0;
 
     while (this.running) {
@@ -174,27 +173,17 @@ export class Recorder {
           );
           if (!evalResult) break;
         }
-        const screenshotResult = await this.raceStop(
-          client.Page.captureScreenshot({
-            format: "jpeg",
-            quality: 60,
-            optimizeForSpeed: true,
+
+        // With --enable-begin-frame-control Chrome only renders when
+        // explicitly told to, giving deterministic frame timing.
+        const frameResult = await this.raceStop(
+          client.HeadlessExperimental.beginFrame({
+            screenshot: { format: "png", optimizeForSpeed: true },
           }),
         );
-        if (!screenshotResult) break;
+        if (!frameResult?.screenshotData) break;
 
-        const buffer = Buffer.from(screenshotResult.data, "base64");
-        const now = Date.now();
-        const elapsed = now - lastFrameTime;
-        const frameSlots = Math.min(3, Math.max(1, Math.round(elapsed / this.frameMs)));
-
-        if (frameSlots > 1) {
-          for (let i = 0; i < frameSlots - 1; i++) {
-            if (this.timeline) this.timeline.tickDuplicate();
-            await this.writeFrame(buffer);
-            this.frameCount++;
-          }
-        }
+        const buffer = Buffer.from(frameResult.screenshotData, "base64");
 
         await this.writeFrame(buffer);
         this.frameCount++;
@@ -204,7 +193,6 @@ export class Recorder {
           writeFileSync(resolve(this.framesDir, `frame-${padded}.jpg`), buffer);
         }
 
-        lastFrameTime = now;
         consecutiveErrors = 0;
       } catch (err) {
         if (!this.running) break;

--- a/packages/@webreel/core/src/types.ts
+++ b/packages/@webreel/core/src/types.ts
@@ -46,6 +46,20 @@ export type CDPClient = {
       mobile: boolean;
     }) => Promise<void>;
   };
+  HeadlessExperimental: {
+    enable: () => Promise<void>;
+    disable: () => Promise<void>;
+    beginFrame: (params?: {
+      frameTimeTicks?: number;
+      interval?: number;
+      noDisplayUpdates?: boolean;
+      screenshot?: {
+        format?: "jpeg" | "png" | "webp";
+        quality?: number;
+        optimizeForSpeed?: boolean;
+      };
+    }) => Promise<{ hasDamage: boolean; screenshotData?: string }>;
+  };
   DOM: {
     enable: () => Promise<void>;
   };

--- a/packages/webreel/src/lib/runner.ts
+++ b/packages/webreel/src/lib/runner.ts
@@ -159,6 +159,27 @@ export async function runVideo(
     clientRef = client;
     await client.Page.enable();
     await client.Runtime.enable();
+    // In headless recording mode, --enable-begin-frame-control means Chrome
+    // won't render anything on its own. We start a background frame pump that
+    // keeps the page alive (JS execution, animations) until the Recorder
+    // takes over with its own beginFrame calls in captureLoop.
+    let framePumpRunning = false;
+    let framePumpBusy = false;
+    let framePumpTimer: ReturnType<typeof setInterval> | null = null;
+    if (shouldRecord) {
+      await client.HeadlessExperimental.enable();
+      framePumpRunning = true;
+      framePumpTimer = setInterval(async () => {
+        if (!framePumpRunning || framePumpBusy) return;
+        framePumpBusy = true;
+        try {
+          await client.HeadlessExperimental.beginFrame();
+        } catch {
+          // Client may be closed or recorder may have taken over
+        }
+        framePumpBusy = false;
+      }, 16);
+    }
     await client.Emulation.setDeviceMetricsOverride({
       width: cssWidth,
       height: cssHeight,
@@ -235,6 +256,19 @@ export async function runVideo(
         sfx: config.sfx,
       });
       recorder.setTimeline(timeline);
+
+      // Stop the background frame pump before handing control to the
+      // recorder's captureLoop, which will call beginFrame itself.
+      framePumpRunning = false;
+      if (framePumpTimer) {
+        clearInterval(framePumpTimer);
+        framePumpTimer = null;
+      }
+      // Wait for any in-flight beginFrame to finish
+      while (framePumpBusy) {
+        await pause(5);
+      }
+
       await recorder.start(client, outputPath, ctx);
     } else {
       ctx.setMode("preview");

--- a/scripts/benchmark.sh
+++ b/scripts/benchmark.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Run on the same machine with localhost:1420 serving the app.
+# Uses webreel.config.json which must output .gif to exercise the full pipeline.
+
+DEMO="${1:-toolbar-demo}"
+RUNS=3
+CLI="node packages/webreel/dist/index.js"
+
+now_ms() {
+  if command -v gdate &>/dev/null; then
+    echo $(($(gdate +%s%N) / 1000000))
+  elif date +%s%N &>/dev/null 2>&1 && [ "$(date +%N)" != "%N" ]; then
+    echo $(($(date +%s%N) / 1000000))
+  else
+    python3 -c 'import time; print(int(time.time()*1000))'
+  fi
+}
+
+echo "=== webreel benchmark: $DEMO ==="
+echo ""
+
+for i in $(seq 1 "$RUNS"); do
+  label="run $i"
+  if [ "$i" -eq 1 ]; then
+    label="run 1 (warmup)"
+  fi
+
+  start=$(now_ms)
+  $CLI record "$DEMO" > /dev/null 2>&1
+  rc=$?
+  end=$(now_ms)
+
+  if [ "$rc" -ne 0 ]; then
+    echo "$label: FAILED (exit code $rc)"
+    exit 1
+  fi
+
+  elapsed=$(echo "scale=2; ($end - $start) / 1000" | bc)
+  echo "$label: ${elapsed}s"
+done
+
+echo ""
+echo "=== output ==="
+OUTPUT=$(find videos/ -name "$DEMO.*" -newer scripts/benchmark.sh 2>/dev/null | head -1)
+if [ -n "$OUTPUT" ]; then
+  SIZE=$(du -h "$OUTPUT" | cut -f1)
+  echo "$OUTPUT: $SIZE"
+fi


### PR DESCRIPTION
Howdy! These changes were made for my own projects that rely on headless
recording. Sharing upstream in case any of it is useful.

## Problem

Three issues prevented reliable headless recording:

1. `Page.captureScreenshot` hangs indefinitely when `--enable-begin-frame-control` is active
2. Cross-device rename (EXDEV) fails on WSL where temp and output dirs are on different filesystems
3. JPEG q60 capture artifacts amplified by re-encoding through x264

## Changes

- Replace `Page.captureScreenshot` with `HeadlessExperimental.beginFrame()` for deterministic frame timing
- Switch capture from JPEG q60 to lossless PNG with `optimizeForSpeed` (54 fps at 1280x720)
- Single-pass GIF output: overlay + palettegen + paletteuse in one ffmpeg filter_complex
- Producer/consumer prefetch queue in compositor (overlaps sharp rendering with ffmpeg I/O)
- Whole-pixel cursor cache key rounding for better overlay cache hit rate
- EXDEV cross-filesystem fallback in media.ts and runner.ts
- Benchmark script (`scripts/benchmark.sh`)

## Results

Test scenario: 9 toolbar clicks, 1280x720, 30fps.

| Format | Before | After | Time | Size |
|--------|--------|-------|------|------|
| GIF | 35.0s / 959K | 27.6s / 341K | -21% | -64% |
| MP4 | 24.5s / 550K | 23.1s / 478K | -6% | -13% |
| WebM | 44.1s / 279K | 45.2s / 284K | ~0% | ~0% |

All 212 tests pass.

Full technical details, per-file breakdown, and capture performance audit are in the commit message.
