### PR TITLE
Fix cross-device rename error when moving recorded videos

### DIFF
--- a/packages/@webreel/core/src/__tests__/fs.test.ts
+++ b/packages/@webreel/core/src/__tests__/fs.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { moveFileSync } from "../fs.js";
+import * as fs from "node:fs";
+
+vi.mock("node:fs", async () => {
+  const actual = await vi.importActual<typeof fs>("node:fs");
+  return {
+    ...actual,
+    renameSync: vi.fn(),
+    copyFileSync: vi.fn(),
+    rmSync: vi.fn(),
+  };
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("moveFileSync", () => {
+  it("uses renameSync when source and dest are on the same device", () => {
+    moveFileSync("/tmp/a.mp4", "/tmp/b.mp4");
+
+    expect(fs.renameSync).toHaveBeenCalledWith("/tmp/a.mp4", "/tmp/b.mp4");
+    expect(fs.copyFileSync).not.toHaveBeenCalled();
+  });
+
+  it("falls back to copy+delete on EXDEV error", () => {
+    const exdev = Object.assign(new Error("cross-device link not permitted"), {
+      code: "EXDEV",
+    });
+    vi.mocked(fs.renameSync).mockImplementation(() => {
+      throw exdev;
+    });
+
+    moveFileSync("/dev1/a.mp4", "/dev2/b.mp4");
+
+    expect(fs.copyFileSync).toHaveBeenCalledWith("/dev1/a.mp4", "/dev2/b.mp4");
+    expect(fs.rmSync).toHaveBeenCalledWith("/dev1/a.mp4", { force: true });
+  });
+
+  it("re-throws non-EXDEV errors", () => {
+    const enoent = Object.assign(new Error("no such file"), { code: "ENOENT" });
+    vi.mocked(fs.renameSync).mockImplementation(() => {
+      throw enoent;
+    });
+
+    expect(() => moveFileSync("/tmp/missing.mp4", "/tmp/b.mp4")).toThrow("no such file");
+    expect(fs.copyFileSync).not.toHaveBeenCalled();
+  });
+});

--- a/packages/@webreel/core/src/fs.ts
+++ b/packages/@webreel/core/src/fs.ts
@@ -1,0 +1,18 @@
+import { renameSync, copyFileSync, rmSync } from "node:fs";
+
+/**
+ * Move a file from `src` to `dest`, falling back to copy+delete when the
+ * source and destination reside on different devices (`EXDEV`).
+ */
+export function moveFileSync(src: string, dest: string): void {
+  try {
+    renameSync(src, dest);
+  } catch (err: unknown) {
+    if ((err as NodeJS.ErrnoException).code === "EXDEV") {
+      copyFileSync(src, dest);
+      rmSync(src, { force: true });
+    } else {
+      throw err;
+    }
+  }
+}

--- a/packages/@webreel/core/src/index.ts
+++ b/packages/@webreel/core/src/index.ts
@@ -41,3 +41,4 @@ export { InteractionTimeline, type TimelineData } from "./timeline.js";
 export { compose, type ComposeOptions } from "./compositor.js";
 export { ensureFfmpeg, FFMPEG_CACHE_DIR } from "./ffmpeg.js";
 export { extractThumbnail, type SfxConfig } from "./media.js";
+export { moveFileSync } from "./fs.js";

--- a/packages/@webreel/core/src/media.ts
+++ b/packages/@webreel/core/src/media.ts
@@ -1,5 +1,6 @@
 import { spawnSync } from "node:child_process";
-import { rmSync, renameSync } from "node:fs";
+import { rmSync } from "node:fs";
+import { moveFileSync } from "./fs.js";
 import { resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import type { SoundEvent } from "./types.js";
@@ -110,7 +111,7 @@ export function finalizeMp4(
         outputPath,
       ]);
     } else {
-      renameSync(tempVideo, outputPath);
+      moveFileSync(tempVideo, outputPath);
     }
     return;
   }
@@ -170,7 +171,7 @@ export function finalizeWebm(
   ]);
 
   if (events.length === 0 || !sfx) {
-    renameSync(silentWebm, outputPath);
+    moveFileSync(silentWebm, outputPath);
     return;
   }
 

--- a/packages/webreel/src/lib/runner.ts
+++ b/packages/webreel/src/lib/runner.ts
@@ -1,5 +1,5 @@
 import { resolve, dirname } from "node:path";
-import { readFileSync, writeFileSync, mkdirSync, renameSync } from "node:fs";
+import { readFileSync, writeFileSync, mkdirSync } from "node:fs";
 import { pathToFileURL } from "node:url";
 import {
   type CDPClient,
@@ -26,6 +26,7 @@ import {
   compose,
   ensureFfmpeg,
   extractThumbnail,
+  moveFileSync,
   DEFAULT_VIEWPORT_SIZE,
 } from "@webreel/core";
 import type { VideoConfig, Step, ElementTarget } from "./types.js";
@@ -430,7 +431,7 @@ export async function runVideo(
         const rawDir = resolve(configDir, ".webreel", "raw");
         mkdirSync(rawDir, { recursive: true });
         const rawVideoPath = resolve(rawDir, `${config.name}.mp4`);
-        renameSync(cleanVideoPath, rawVideoPath);
+        moveFileSync(cleanVideoPath, rawVideoPath);
 
         ctx.setMode("preview");
         ctx.setTimeline(null);


### PR DESCRIPTION
## Summary
- Adds `moveFileSync` helper in `@webreel/core` that wraps `renameSync` with a `copyFileSync` + `rmSync` fallback for cross-device (`EXDEV`) errors
- Replaces all three `renameSync` call sites in `media.ts` and `runner.ts` with `moveFileSync`
- Adds unit tests for same-device rename, EXDEV fallback, and error propagation

Fixes #14

## Test plan
- [x] Unit tests: 3 new tests covering `moveFileSync` behavior (same-device, EXDEV fallback, ENOENT propagation)
- [x] All existing tests pass (210 total)
- [x] E2E reproduction: confirmed EXDEV error using `/dev/shm` (tmpfs) → `/tmp` (xfs) cross-device rename
- [x] E2E verification: confirmed `moveFileSync` handles the cross-device move correctly
- [x] Lint, format, and build all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)