### PR TITLE
feat: multi-config support (extends, scenarios, list, --project)

### DIFF
--- a/apps/docs/src/app/commands/page.mdx
+++ b/apps/docs/src/app/commands/page.mdx
@@ -1,7 +1,7 @@
 export const metadata = {
   title: "Commands",
   description:
-    "CLI commands available in webreel: init, record, preview, composite, install, and validate.",
+    "CLI commands available in webreel: init, record, preview, composite, list, install, and validate.",
 };
 
 # Commands
@@ -53,10 +53,14 @@ Record videos:
 webreel record
 webreel record hero login
 webreel record -c custom.config.json
+webreel record -c web.json -c mobile.json
+webreel record -p "dashboard-*"
 webreel record --watch
 ```
 
 When run without arguments, webreel finds the nearest config file (searching parent directories) and records all videos. Provide video names to record specific videos only.
+
+The `-c` flag can be repeated to load multiple config files, and supports globs (e.g. `-c "configs/*.json"`). The `-p` flag filters videos by name or glob pattern.
 
 <table>
   <thead>
@@ -70,7 +74,13 @@ When run without arguments, webreel finds the nearest config file (searching par
       <td>
         <code>-c</code>, <code>--config</code>
       </td>
-      <td>Path to config file (default: auto-discovered)</td>
+      <td>Config file path or glob (repeatable, default: auto-discovered)</td>
+    </tr>
+    <tr>
+      <td>
+        <code>-p</code>, <code>--project</code>
+      </td>
+      <td>Filter videos by name or glob pattern (repeatable)</td>
     </tr>
     <tr>
       <td>
@@ -89,6 +99,12 @@ When run without arguments, webreel finds the nearest config file (searching par
         <code>--dry-run</code>
       </td>
       <td>Print the fully resolved config and step list without recording</td>
+    </tr>
+    <tr>
+      <td>
+        <code>--frames</code>
+      </td>
+      <td>Save raw frames as JPEGs in .webreel/frames/</td>
     </tr>
   </tbody>
 </table>
@@ -117,7 +133,7 @@ When run without a video name, the first video in the config is previewed.
       <td>
         <code>-c</code>, <code>--config</code>
       </td>
-      <td>Path to config file (default: webreel.config.json)</td>
+      <td>Config file path or glob (repeatable)</td>
     </tr>
     <tr>
       <td>
@@ -136,6 +152,7 @@ Re-composite videos from stored raw recordings and timelines. This re-applies cu
 webreel composite
 webreel composite hero
 webreel composite -c custom.config.json
+webreel composite -p "mobile-*"
 ```
 
 Raw video and timeline data are stored in `.webreel/raw/` and `.webreel/timelines/` after the first recording.
@@ -152,7 +169,55 @@ Raw video and timeline data are stored in `.webreel/raw/` and `.webreel/timeline
       <td>
         <code>-c</code>, <code>--config</code>
       </td>
-      <td>Path to config file (default: webreel.config.json)</td>
+      <td>Config file path or glob (repeatable)</td>
+    </tr>
+    <tr>
+      <td>
+        <code>-p</code>, <code>--project</code>
+      </td>
+      <td>Filter videos by name or glob pattern (repeatable)</td>
+    </tr>
+  </tbody>
+</table>
+
+## list
+
+List all videos across config file(s):
+
+```bash
+webreel list
+webreel list -c web.json -c mobile.json
+webreel list -p "dashboard-*"
+webreel list --json
+```
+
+Shows video names, URLs, source config files, step counts, and viewports. Use `--json` for machine-readable output.
+
+<table>
+  <thead>
+    <tr>
+      <th>Flag</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>
+        <code>-c</code>, <code>--config</code>
+      </td>
+      <td>Config file path or glob (repeatable)</td>
+    </tr>
+    <tr>
+      <td>
+        <code>-p</code>, <code>--project</code>
+      </td>
+      <td>Filter videos by name or glob pattern (repeatable)</td>
+    </tr>
+    <tr>
+      <td>
+        <code>--json</code>
+      </td>
+      <td>Output as JSON</td>
     </tr>
   </tbody>
 </table>
@@ -185,12 +250,15 @@ webreel install --force
 
 ## validate
 
-Check a config file for errors without running it:
+Check config file(s) for errors without running them:
 
 ```bash
 webreel validate
 webreel validate -c custom.config.json
+webreel validate -c web.json -c mobile.json
 ```
+
+When multiple configs are specified, cross-config validation checks for duplicate video names.
 
 <table>
   <thead>
@@ -204,7 +272,7 @@ webreel validate -c custom.config.json
       <td>
         <code>-c</code>, <code>--config</code>
       </td>
-      <td>Path to config file (default: webreel.config.json)</td>
+      <td>Config file path or glob (repeatable)</td>
     </tr>
   </tbody>
 </table>

--- a/apps/docs/src/app/commands/page.mdx
+++ b/apps/docs/src/app/commands/page.mdx
@@ -54,13 +54,13 @@ webreel record
 webreel record hero login
 webreel record -c custom.config.json
 webreel record -c web.json -c mobile.json
-webreel record -p "dashboard-*"
+webreel record -f "dashboard-*"
 webreel record --watch
 ```
 
 When run without arguments, webreel finds the nearest config file (searching parent directories) and records all videos. Provide video names to record specific videos only.
 
-The `-c` flag can be repeated to load multiple config files, and supports globs (e.g. `-c "configs/*.json"`). The `-p` flag filters videos by name or glob pattern.
+The `-c` flag can be repeated to load multiple config files, and supports globs (e.g. `-c "configs/*.json"`). The `-f` flag filters videos by name or glob pattern.
 
 <table>
   <thead>
@@ -78,7 +78,7 @@ The `-c` flag can be repeated to load multiple config files, and supports globs 
     </tr>
     <tr>
       <td>
-        <code>-p</code>, <code>--project</code>
+        <code>-f</code>, <code>--filter</code>
       </td>
       <td>Filter videos by name or glob pattern (repeatable)</td>
     </tr>
@@ -137,6 +137,12 @@ When run without a video name, the first video in the config is previewed.
     </tr>
     <tr>
       <td>
+        <code>-f</code>, <code>--filter</code>
+      </td>
+      <td>Filter videos by name or glob pattern (repeatable)</td>
+    </tr>
+    <tr>
+      <td>
         <code>--verbose</code>
       </td>
       <td>Log each step as it executes</td>
@@ -152,7 +158,7 @@ Re-composite videos from stored raw recordings and timelines. This re-applies cu
 webreel composite
 webreel composite hero
 webreel composite -c custom.config.json
-webreel composite -p "mobile-*"
+webreel composite -f "mobile-*"
 ```
 
 Raw video and timeline data are stored in `.webreel/raw/` and `.webreel/timelines/` after the first recording.
@@ -173,7 +179,7 @@ Raw video and timeline data are stored in `.webreel/raw/` and `.webreel/timeline
     </tr>
     <tr>
       <td>
-        <code>-p</code>, <code>--project</code>
+        <code>-f</code>, <code>--filter</code>
       </td>
       <td>Filter videos by name or glob pattern (repeatable)</td>
     </tr>
@@ -187,7 +193,7 @@ List all videos across config file(s):
 ```bash
 webreel list
 webreel list -c web.json -c mobile.json
-webreel list -p "dashboard-*"
+webreel list -f "dashboard-*"
 webreel list --json
 ```
 
@@ -209,7 +215,7 @@ Shows video names, URLs, source config files, step counts, and viewports. Use `-
     </tr>
     <tr>
       <td>
-        <code>-p</code>, <code>--project</code>
+        <code>-f</code>, <code>--filter</code>
       </td>
       <td>Filter videos by name or glob pattern (repeatable)</td>
     </tr>

--- a/apps/docs/src/app/configuration/page.mdx
+++ b/apps/docs/src/app/configuration/page.mdx
@@ -133,10 +133,27 @@ These fields apply as defaults to all videos and can be overridden per-video.
     </tr>
     <tr>
       <td>
+        <code>extends</code>
+      </td>
+      <td>-</td>
+      <td>Path to a base config file to inherit from</td>
+    </tr>
+    <tr>
+      <td>
+        <code>scenarios</code>
+      </td>
+      <td>-</td>
+      <td>Array of glob patterns and/or inline scenario configs</td>
+    </tr>
+    <tr>
+      <td>
         <code>videos</code>
       </td>
-      <td>required</td>
-      <td>Object mapping video names to their configurations</td>
+      <td>required*</td>
+      <td>
+        Object mapping video names to their configurations. Optional when{" "}
+        <code>scenarios</code> is present.
+      </td>
     </tr>
   </tbody>
 </table>
@@ -906,6 +923,114 @@ import type { InputWebreelConfig } from "webreel";
 ```
 
 JavaScript configs (`webreel.config.js`, `webreel.config.mjs`) work the same way: just `export default` a config object.
+
+## extends
+
+A config file can inherit from a base config using the `extends` field. The base config's top-level options, theme, sfx, and videos are merged with the child config. Child values take precedence.
+
+```json
+// base.json
+{
+  "baseUrl": "https://myapp.com",
+  "viewport": "desktop",
+  "theme": { "cursor": { "size": 32 } },
+  "videos": {
+    "shared-intro": { "url": "/", "steps": [] }
+  }
+}
+```
+
+```json
+// webreel.config.json
+{
+  "extends": "./base.json",
+  "theme": { "cursor": { "hotspot": "center" } },
+  "videos": {
+    "hero": { "url": "/hero", "steps": [] }
+  }
+}
+```
+
+The resolved config inherits `baseUrl`, `viewport`, and the `shared-intro` video from the base. The `theme.cursor` is shallow-merged: `{ "size": 32, "hotspot": "center" }`. The child's `hero` video is added alongside the base's `shared-intro`.
+
+Chains are supported (a base can extend another base), up to 10 levels deep. Circular references are detected and reported.
+
+## scenarios
+
+For projects with many demo videos, the `scenarios` field lets you organize configs across multiple files or inline groups. Each scenario is loaded independently, and all videos are collected into a single run.
+
+```json
+{
+  "baseUrl": "https://myapp.com",
+  "scenarios": [
+    "./demos/*.webreel.json",
+    {
+      "extends": true,
+      "videos": {
+        "login": { "url": "/login", "steps": [] }
+      }
+    }
+  ],
+  "videos": {
+    "hero": { "url": "/", "steps": [] }
+  }
+}
+```
+
+Scenario entries can be:
+
+- **Glob strings** that match config files (e.g. `"./demos/*.webreel.json"`). Each matched file is loaded as a standalone config.
+- **Inline objects** with their own `videos`, `baseUrl`, `theme`, etc. Use `"extends": true` to inherit top-level options from the root config.
+
+The `videos` field is optional when `scenarios` is present. This lets you use a root config purely as an orchestrator.
+
+### defineScenario
+
+For TypeScript configs, use the `defineScenario` helper for inline scenario objects:
+
+```ts
+import { defineConfig, defineScenario } from "webreel";
+
+export default defineConfig({
+  baseUrl: "https://myapp.com",
+  scenarios: [
+    "./demos/*.webreel.ts",
+    defineScenario({
+      extends: true,
+      videos: {
+        login: { url: "/login", steps: [] },
+      },
+    }),
+  ],
+});
+```
+
+## Multiple configs
+
+Use `--config` (or `-c`) multiple times to load several config files in a single run. All videos are merged and deduplicated by name.
+
+```bash
+webreel record -c web.config.json -c mobile.config.json
+webreel list -c ./configs/*.json
+```
+
+Glob patterns are supported. If any two configs define a video with the same name, an error is reported.
+
+## --project filtering
+
+The `--project` flag (or `-p`) filters videos by name using exact match or glob patterns. It can be repeated.
+
+```bash
+webreel record -p hero -p "dashboard-*"
+webreel list -p "mobile-*"
+```
+
+When combined with positional video names, the results are unioned:
+
+```bash
+# Records "hero" (by name) and all videos matching "dashboard-*" (by project)
+webreel record hero -p "dashboard-*"
+```
 
 ## Dry run
 

--- a/apps/docs/src/app/configuration/page.mdx
+++ b/apps/docs/src/app/configuration/page.mdx
@@ -1016,20 +1016,20 @@ webreel list -c ./configs/*.json
 
 Glob patterns are supported. If any two configs define a video with the same name, an error is reported.
 
-## --project filtering
+## --filter
 
-The `--project` flag (or `-p`) filters videos by name using exact match or glob patterns. It can be repeated.
+The `--filter` flag (or `-f`) filters videos by name using exact match or glob patterns. It can be repeated.
 
 ```bash
-webreel record -p hero -p "dashboard-*"
-webreel list -p "mobile-*"
+webreel record -f hero -f "dashboard-*"
+webreel list -f "mobile-*"
 ```
 
 When combined with positional video names, the results are unioned:
 
 ```bash
-# Records "hero" (by name) and all videos matching "dashboard-*" (by project)
-webreel record hero -p "dashboard-*"
+# Records "hero" (by name) and all videos matching "dashboard-*" (by filter)
+webreel record hero -f "dashboard-*"
 ```
 
 ## Dry run

--- a/packages/webreel/package.json
+++ b/packages/webreel/package.json
@@ -54,10 +54,13 @@
     "@webreel/core": "workspace:*",
     "commander": "^14.0.3",
     "jiti": "^2.6.1",
-    "jsonc-parser": "^3.3.1"
+    "jsonc-parser": "^3.3.1",
+    "picomatch": "^4.0.3",
+    "tinyglobby": "^0.2.15"
   },
   "devDependencies": {
     "@types/node": "25.3.0",
+    "@types/picomatch": "^4.0.2",
     "typescript": "5.9.3"
   }
 }

--- a/packages/webreel/src/commands/__tests__/record.test.ts
+++ b/packages/webreel/src/commands/__tests__/record.test.ts
@@ -1,96 +1,80 @@
 import { describe, it, expect } from "vitest";
-import { resolve, dirname } from "node:path";
+import { resolve } from "node:path";
 import { collectIncludePaths } from "../record.js";
-import type { WebreelConfig } from "../../lib/types.js";
+import type { FullConfig, VideoConfig } from "../../lib/types.js";
 
 describe("collectIncludePaths", () => {
-  const configPath = "/project/webreel.config.json";
-  const configDir = dirname(configPath);
+  const configDir = "/project";
 
-  function makeConfig(overrides: Partial<WebreelConfig> = {}): WebreelConfig {
+  function makeFull(videos: Partial<VideoConfig>[]): FullConfig {
     return {
-      videos: [
-        {
-          name: "test",
-          url: "https://example.com",
-          steps: [],
-        },
-      ],
-      ...overrides,
+      videos: videos.map((v, i) => ({
+        name: `v${i}`,
+        configDir,
+        url: "https://example.com",
+        steps: [],
+        ...v,
+      })) as VideoConfig[],
+      videoSources: new Map(),
     };
   }
 
   it("returns empty array when no includes exist", () => {
-    const config = makeConfig();
-    expect(collectIncludePaths(config, configPath)).toEqual([]);
+    const full = makeFull([{}]);
+    expect(collectIncludePaths(full)).toEqual([]);
   });
 
-  it("resolves top-level include paths relative to config dir", () => {
-    const config = makeConfig({ include: ["steps/setup.json"] });
-    const result = collectIncludePaths(config, configPath);
+  it("resolves per-video include paths relative to video configDir", () => {
+    const full = makeFull([{ include: ["steps/setup.json"] }]);
+    const result = collectIncludePaths(full);
     expect(result).toEqual([resolve(configDir, "steps/setup.json")]);
   });
 
-  it("resolves per-video include paths", () => {
-    const config = makeConfig({
-      videos: [
-        {
-          name: "v1",
-          url: "https://example.com",
-          steps: [],
-          include: ["steps/v1-setup.json"],
-        },
-      ],
-    });
-    const result = collectIncludePaths(config, configPath);
-    expect(result).toEqual([resolve(configDir, "steps/v1-setup.json")]);
-  });
-
-  it("combines top-level and per-video includes", () => {
-    const config = makeConfig({
-      include: ["steps/shared.json"],
-      videos: [
-        {
-          name: "v1",
-          url: "https://example.com",
-          steps: [],
-          include: ["steps/v1.json"],
-        },
-        {
-          name: "v2",
-          url: "https://example.com",
-          steps: [],
-          include: ["steps/v2.json"],
-        },
-      ],
-    });
-    const result = collectIncludePaths(config, configPath);
+  it("combines includes from multiple videos", () => {
+    const full = makeFull([
+      { include: ["steps/v1.json"] },
+      { include: ["steps/v2.json"] },
+    ]);
+    const result = collectIncludePaths(full);
     expect(result).toEqual([
-      resolve(configDir, "steps/shared.json"),
       resolve(configDir, "steps/v1.json"),
       resolve(configDir, "steps/v2.json"),
     ]);
   });
 
   it("deduplicates identical paths", () => {
-    const config = makeConfig({
-      include: ["steps/setup.json"],
+    const full = makeFull([
+      { include: ["steps/setup.json"] },
+      { include: ["steps/setup.json"] },
+    ]);
+    const result = collectIncludePaths(full);
+    expect(result).toEqual([resolve(configDir, "steps/setup.json")]);
+  });
+
+  it("uses different configDir per video", () => {
+    const full: FullConfig = {
       videos: [
         {
-          name: "v1",
+          name: "a",
+          configDir: "/projectA",
           url: "https://example.com",
           steps: [],
-          include: ["steps/setup.json"],
-        },
+          include: ["steps/a.json"],
+        } as VideoConfig,
         {
-          name: "v2",
+          name: "b",
+          configDir: "/projectB",
           url: "https://example.com",
           steps: [],
-          include: ["steps/setup.json"],
-        },
+          include: ["steps/b.json"],
+        } as VideoConfig,
       ],
-    });
-    const result = collectIncludePaths(config, configPath);
-    expect(result).toEqual([resolve(configDir, "steps/setup.json")]);
+      videoSources: new Map(),
+    };
+    const result = collectIncludePaths(full);
+    expect(result).toEqual([
+      resolve("/projectA", "steps/a.json"),
+      resolve("/projectB", "steps/b.json"),
+    ]);
   });
 });

--- a/packages/webreel/src/commands/composite.ts
+++ b/packages/webreel/src/commands/composite.ts
@@ -2,28 +2,35 @@ import { Command } from "commander";
 import { readFileSync, existsSync, mkdirSync } from "node:fs";
 import { resolve, dirname } from "node:path";
 import { compose, type TimelineData } from "@webreel/core";
-import {
-  loadWebreelConfig,
-  resolveConfigPath,
-  getConfigDir,
-  filterVideosByName,
-} from "../lib/config.js";
+import { loadFullConfig, resolveConfigPaths, filterVideos } from "../lib/config.js";
 import { extractThumbnailIfConfigured } from "../lib/runner.js";
+
+function accumulate(val: string, prev: string[]): string[] {
+  return [...prev, val];
+}
 
 export const compositeCommand = new Command("composite")
   .description("Re-composite videos from stored raw recordings and timelines")
   .argument("[videos...]", "Video names to composite (default: all)")
-  .option("-c, --config <path>", "Path to config file (default: webreel.config.json)")
-  .action(async (videoNames: string[], opts: { config?: string }) => {
-    const configPath = resolveConfigPath(opts.config);
-    const configDir = getConfigDir(configPath);
-    const webreelConfig = await loadWebreelConfig(configPath);
-    const videos = filterVideosByName(webreelConfig.videos, videoNames);
+  .option("-c, --config <path>", "Config file (repeatable)", accumulate, [])
+  .option(
+    "-p, --project <name>",
+    "Filter by project name/glob (repeatable)",
+    accumulate,
+    [],
+  )
+  .action(async (videoNames: string[], opts: { config: string[]; project: string[] }) => {
+    const configPaths = await resolveConfigPaths(
+      opts.config.length > 0 ? opts.config : undefined,
+    );
+    const fullConfig = await loadFullConfig(configPaths);
+    const videos = filterVideos(fullConfig.videos, videoNames, opts.project);
 
     for (const video of videos) {
-      const rawPath = resolve(configDir, ".webreel", "raw", `${video.name}.mp4`);
+      const videoDir = video.configDir;
+      const rawPath = resolve(videoDir, ".webreel", "raw", `${video.name}.mp4`);
       const timelinePath = resolve(
-        configDir,
+        videoDir,
         ".webreel",
         "timelines",
         `${video.name}.timeline.json`,
@@ -44,8 +51,7 @@ export const compositeCommand = new Command("composite")
       } catch (err) {
         throw new Error(`Invalid timeline file: ${timelinePath}`, { cause: err });
       }
-      const outputPath =
-        video.output ?? resolve(configDir, "videos", `${video.name}.mp4`);
+      const outputPath = video.output ?? resolve(videoDir, "videos", `${video.name}.mp4`);
 
       mkdirSync(dirname(outputPath), { recursive: true });
       console.log(`Compositing: ${video.name}`);

--- a/packages/webreel/src/commands/composite.ts
+++ b/packages/webreel/src/commands/composite.ts
@@ -13,18 +13,13 @@ export const compositeCommand = new Command("composite")
   .description("Re-composite videos from stored raw recordings and timelines")
   .argument("[videos...]", "Video names to composite (default: all)")
   .option("-c, --config <path>", "Config file (repeatable)", accumulate, [])
-  .option(
-    "-p, --project <name>",
-    "Filter by project name/glob (repeatable)",
-    accumulate,
-    [],
-  )
-  .action(async (videoNames: string[], opts: { config: string[]; project: string[] }) => {
+  .option("-f, --filter <name>", "Filter by video name/glob (repeatable)", accumulate, [])
+  .action(async (videoNames: string[], opts: { config: string[]; filter: string[] }) => {
     const configPaths = await resolveConfigPaths(
       opts.config.length > 0 ? opts.config : undefined,
     );
     const fullConfig = await loadFullConfig(configPaths);
-    const videos = filterVideos(fullConfig.videos, videoNames, opts.project);
+    const videos = filterVideos(fullConfig.videos, videoNames, opts.filter);
 
     for (const video of videos) {
       const videoDir = video.configDir;

--- a/packages/webreel/src/commands/list.ts
+++ b/packages/webreel/src/commands/list.ts
@@ -1,0 +1,56 @@
+import { Command } from "commander";
+import { loadFullConfig, resolveConfigPaths, filterVideos } from "../lib/config.js";
+
+function accumulate(val: string, prev: string[]): string[] {
+  return [...prev, val];
+}
+
+export const listCommand = new Command("list")
+  .description("List all videos across config(s)")
+  .option("-c, --config <path>", "Config file (repeatable)", accumulate, [])
+  .option(
+    "-p, --project <name>",
+    "Filter by project name/glob (repeatable)",
+    accumulate,
+    [],
+  )
+  .option("--json", "Output as JSON")
+  .action(async (opts: { config: string[]; project: string[]; json?: boolean }) => {
+    const configPaths = await resolveConfigPaths(
+      opts.config.length > 0 ? opts.config : undefined,
+    );
+    const fullConfig = await loadFullConfig(configPaths);
+    const videos = filterVideos(fullConfig.videos, [], opts.project);
+
+    if (opts.json) {
+      const data = videos.map((v) => ({
+        name: v.name,
+        url: v.url,
+        source: fullConfig.videoSources.get(v.name) ?? null,
+        steps: v.steps.length,
+        viewport: v.viewport ?? null,
+        output: v.output ?? null,
+      }));
+      console.log(JSON.stringify(data, null, 2));
+      return;
+    }
+
+    const dim = (s: string) => `\x1b[2m${s}\x1b[0m`;
+    const cyan = (s: string) => `\x1b[36m${s}\x1b[0m`;
+
+    console.log(`\n${videos.length} video(s):\n`);
+
+    for (const video of videos) {
+      const source = fullConfig.videoSources.get(video.name);
+      const sourceLabel = source ? dim(` (${source})`) : "";
+      const viewport = video.viewport
+        ? dim(` ${video.viewport.width}x${video.viewport.height}`)
+        : "";
+      const steps = dim(` ${video.steps.length} step(s)`);
+
+      console.log(`  ${cyan(video.name)}${sourceLabel}`);
+      console.log(`    ${video.url}${viewport}${steps}`);
+    }
+
+    console.log();
+  });

--- a/packages/webreel/src/commands/list.ts
+++ b/packages/webreel/src/commands/list.ts
@@ -8,19 +8,14 @@ function accumulate(val: string, prev: string[]): string[] {
 export const listCommand = new Command("list")
   .description("List all videos across config(s)")
   .option("-c, --config <path>", "Config file (repeatable)", accumulate, [])
-  .option(
-    "-p, --project <name>",
-    "Filter by project name/glob (repeatable)",
-    accumulate,
-    [],
-  )
+  .option("-f, --filter <name>", "Filter by video name/glob (repeatable)", accumulate, [])
   .option("--json", "Output as JSON")
-  .action(async (opts: { config: string[]; project: string[]; json?: boolean }) => {
+  .action(async (opts: { config: string[]; filter: string[]; json?: boolean }) => {
     const configPaths = await resolveConfigPaths(
       opts.config.length > 0 ? opts.config : undefined,
     );
     const fullConfig = await loadFullConfig(configPaths);
-    const videos = filterVideos(fullConfig.videos, [], opts.project);
+    const videos = filterVideos(fullConfig.videos, [], opts.filter);
 
     if (opts.json) {
       const data = videos.map((v) => ({

--- a/packages/webreel/src/commands/preview.ts
+++ b/packages/webreel/src/commands/preview.ts
@@ -1,39 +1,44 @@
 import { Command } from "commander";
-import { loadWebreelConfig, resolveConfigPath, getConfigDir } from "../lib/config.js";
+import { loadFullConfig, resolveConfigPaths } from "../lib/config.js";
 import { runVideo } from "../lib/runner.js";
+
+function accumulate(val: string, prev: string[]): string[] {
+  return [...prev, val];
+}
 
 export const previewCommand = new Command("preview")
   .description("Run a video in a visible browser without recording")
   .argument("[video]", "Video name to preview (default: first video)")
-  .option("-c, --config <path>", "Path to config file (default: webreel.config.json)")
+  .option("-c, --config <path>", "Config file (repeatable)", accumulate, [])
   .option("--verbose", "Log each step as it executes")
   .action(
     async (
       videoName: string | undefined,
-      opts: { config?: string; verbose?: boolean },
+      opts: { config: string[]; verbose?: boolean },
     ) => {
-      const configPath = resolveConfigPath(opts.config);
-      const configDir = getConfigDir(configPath);
+      const configPaths = await resolveConfigPaths(
+        opts.config.length > 0 ? opts.config : undefined,
+      );
       const verbose = opts.verbose ?? false;
 
-      const webreelConfig = await loadWebreelConfig(configPath);
+      const fullConfig = await loadFullConfig(configPaths);
 
       let video;
       if (videoName) {
-        video = webreelConfig.videos.find((v) => v.name === videoName);
+        video = fullConfig.videos.find((v) => v.name === videoName);
         if (!video) {
           throw new Error(
-            `Video "${videoName}" not found. Available: ${webreelConfig.videos.map((v) => v.name).join(", ")}`,
+            `Video "${videoName}" not found. Available: ${fullConfig.videos.map((v) => v.name).join(", ")}`,
           );
         }
       } else {
-        video = webreelConfig.videos[0];
+        video = fullConfig.videos[0];
         if (!video) {
           throw new Error("No videos defined in config.");
         }
       }
 
       console.log(`\nPreviewing: ${video.name}`);
-      await runVideo(video, { record: false, verbose, configDir });
+      await runVideo(video, { record: false, verbose, configDir: video.configDir });
     },
   );

--- a/packages/webreel/src/commands/preview.ts
+++ b/packages/webreel/src/commands/preview.ts
@@ -1,5 +1,5 @@
 import { Command } from "commander";
-import { loadFullConfig, resolveConfigPaths } from "../lib/config.js";
+import { loadFullConfig, resolveConfigPaths, filterVideos } from "../lib/config.js";
 import { runVideo } from "../lib/runner.js";
 
 function accumulate(val: string, prev: string[]): string[] {
@@ -10,11 +10,12 @@ export const previewCommand = new Command("preview")
   .description("Run a video in a visible browser without recording")
   .argument("[video]", "Video name to preview (default: first video)")
   .option("-c, --config <path>", "Config file (repeatable)", accumulate, [])
+  .option("-f, --filter <name>", "Filter by video name/glob (repeatable)", accumulate, [])
   .option("--verbose", "Log each step as it executes")
   .action(
     async (
       videoName: string | undefined,
-      opts: { config: string[]; verbose?: boolean },
+      opts: { config: string[]; filter: string[]; verbose?: boolean },
     ) => {
       const configPaths = await resolveConfigPaths(
         opts.config.length > 0 ? opts.config : undefined,
@@ -22,20 +23,21 @@ export const previewCommand = new Command("preview")
       const verbose = opts.verbose ?? false;
 
       const fullConfig = await loadFullConfig(configPaths);
+      const filtered = filterVideos(
+        fullConfig.videos,
+        videoName ? [videoName] : [],
+        opts.filter,
+      );
 
-      let video;
-      if (videoName) {
-        video = fullConfig.videos.find((v) => v.name === videoName);
-        if (!video) {
-          throw new Error(
-            `Video "${videoName}" not found. Available: ${fullConfig.videos.map((v) => v.name).join(", ")}`,
-          );
-        }
-      } else {
-        video = fullConfig.videos[0];
-        if (!video) {
-          throw new Error("No videos defined in config.");
-        }
+      if (filtered.length === 0) {
+        throw new Error("No videos defined in config.");
+      }
+
+      const video = filtered[0];
+      if (filtered.length > 1) {
+        console.log(
+          `Matched ${filtered.length} video(s). Previewing first match. Use video name for a specific video.`,
+        );
       }
 
       console.log(`\nPreviewing: ${video.name}`);

--- a/packages/webreel/src/commands/record.ts
+++ b/packages/webreel/src/commands/record.ts
@@ -1,48 +1,35 @@
 import { Command } from "commander";
 import { watch, type FSWatcher } from "node:fs";
 import { resolve } from "node:path";
-import {
-  loadWebreelConfig,
-  resolveConfigPath,
-  getConfigDir,
-  filterVideosByName,
-} from "../lib/config.js";
+import { loadFullConfig, resolveConfigPaths, filterVideos } from "../lib/config.js";
 import { runVideo } from "../lib/runner.js";
-import type { WebreelConfig } from "../lib/types.js";
+import type { FullConfig, VideoConfig } from "../lib/types.js";
 
-export function collectIncludePaths(config: WebreelConfig, configPath: string): string[] {
-  const configDir = getConfigDir(configPath);
+export function collectIncludePaths(full: FullConfig): string[] {
   const paths: string[] = [];
-  const topIncludes = config.include ?? [];
-  for (const inc of topIncludes) {
-    paths.push(resolve(configDir, inc));
-  }
-  for (const video of config.videos) {
+  for (const video of full.videos) {
+    const videoDir = video.configDir;
     for (const inc of video.include ?? []) {
-      paths.push(resolve(configDir, inc));
+      paths.push(resolve(videoDir, inc));
     }
   }
   return [...new Set(paths)];
 }
 
-function printResolvedConfig(config: WebreelConfig): void {
+function printResolvedConfig(
+  videos: VideoConfig[],
+  videoSources?: Map<string, string>,
+): void {
   const dim = (s: string) => `\x1b[2m${s}\x1b[0m`;
   const bold = (s: string) => `\x1b[1m${s}\x1b[0m`;
   const cyan = (s: string) => `\x1b[36m${s}\x1b[0m`;
 
-  console.log(bold("\nResolved configuration:\n"));
+  console.log(bold(`\n${videos.length} video(s):\n`));
 
-  if (config.baseUrl) console.log(`  baseUrl:      ${config.baseUrl}`);
-  if (config.outDir) console.log(`  outDir:       ${config.outDir}`);
-  if (config.viewport)
-    console.log(`  viewport:     ${config.viewport.width}x${config.viewport.height}`);
-  if (config.defaultDelay !== undefined)
-    console.log(`  defaultDelay: ${config.defaultDelay}ms`);
-
-  console.log(`\n  ${bold(`${config.videos.length} video(s):`)}\n`);
-
-  for (const video of config.videos) {
-    console.log(`  ${cyan(video.name)}`);
+  for (const video of videos) {
+    const source = videoSources?.get(video.name);
+    const label = source ? ` ${dim(`(${source})`)}` : "";
+    console.log(`  ${cyan(video.name)}${label}`);
     console.log(`    url:      ${video.url}`);
     if (video.viewport)
       console.log(`    viewport: ${video.viewport.width}x${video.viewport.height}`);
@@ -68,10 +55,20 @@ function printResolvedConfig(config: WebreelConfig): void {
   }
 }
 
+function accumulate(val: string, prev: string[]): string[] {
+  return [...prev, val];
+}
+
 export const recordCommand = new Command("record")
   .description("Record videos")
   .argument("[videos...]", "Video names to record (default: all)")
-  .option("-c, --config <path>", "Path to config file (default: webreel.config.json)")
+  .option("-c, --config <path>", "Config file (repeatable)", accumulate, [])
+  .option(
+    "-p, --project <name>",
+    "Filter by project name/glob (repeatable)",
+    accumulate,
+    [],
+  )
   .option("--verbose", "Log each step as it executes")
   .option("--watch", "Re-record when config files change")
   .option("--dry-run", "Print the resolved config and step list without recording")
@@ -80,28 +77,34 @@ export const recordCommand = new Command("record")
     async (
       videoNames: string[],
       opts: {
-        config?: string;
+        config: string[];
+        project: string[];
         verbose?: boolean;
         watch?: boolean;
         dryRun?: boolean;
         frames?: boolean;
       },
     ) => {
-      const configPath = resolveConfigPath(opts.config);
-      const configDir = getConfigDir(configPath);
+      const configPaths = await resolveConfigPaths(
+        opts.config.length > 0 ? opts.config : undefined,
+      );
       const verbose = opts.verbose ?? false;
 
-      const webreelConfig = await loadWebreelConfig(configPath);
-      const videos = filterVideosByName(webreelConfig.videos, videoNames);
+      const fullConfig = await loadFullConfig(configPaths);
+      const videos = filterVideos(fullConfig.videos, videoNames, opts.project);
 
       if (opts.dryRun) {
-        const filtered = { ...webreelConfig, videos };
-        printResolvedConfig(filtered);
+        printResolvedConfig(videos, fullConfig.videoSources);
         return;
       }
 
       for (const video of videos) {
-        await runVideo(video, { record: true, verbose, configDir, frames: opts.frames });
+        await runVideo(video, {
+          record: true,
+          verbose,
+          configDir: video.configDir,
+          frames: opts.frames,
+        });
       }
 
       if (opts.watch) {
@@ -115,10 +118,12 @@ export const recordCommand = new Command("record")
           watchers.length = 0;
         };
 
-        const setupWatchers = (cfg: WebreelConfig) => {
+        const setupWatchers = (full: FullConfig) => {
           closeAllWatchers();
-          watchers.push(watch(configPath, onFileChange));
-          for (const p of collectIncludePaths(cfg, configPath)) {
+          for (const cp of configPaths) {
+            watchers.push(watch(cp, onFileChange));
+          }
+          for (const p of collectIncludePaths(full)) {
             watchers.push(watch(p, onFileChange));
           }
         };
@@ -129,16 +134,20 @@ export const recordCommand = new Command("record")
           timer = setTimeout(async () => {
             timer = null;
             console.log("\nRe-recording...");
-            let latestConfig: WebreelConfig | null = null;
+            let latestConfig: FullConfig | null = null;
             const run = (async () => {
               try {
-                latestConfig = await loadWebreelConfig(configPath);
-                const updatedVideos = filterVideosByName(latestConfig.videos, videoNames);
+                latestConfig = await loadFullConfig(configPaths);
+                const updatedVideos = filterVideos(
+                  latestConfig.videos,
+                  videoNames,
+                  opts.project,
+                );
                 for (const video of updatedVideos) {
                   await runVideo(video, {
                     record: true,
                     verbose,
-                    configDir,
+                    configDir: video.configDir,
                     frames: opts.frames,
                   });
                 }
@@ -146,7 +155,7 @@ export const recordCommand = new Command("record")
                 console.error(`Error re-recording:`, err);
               } finally {
                 recordingInProgress = null;
-                setupWatchers(latestConfig ?? webreelConfig);
+                setupWatchers(latestConfig ?? fullConfig);
               }
             })();
             recordingInProgress = run;
@@ -154,7 +163,7 @@ export const recordCommand = new Command("record")
           }, 300);
         };
 
-        setupWatchers(webreelConfig);
+        setupWatchers(fullConfig);
 
         process.on("SIGINT", async () => {
           closeAllWatchers();

--- a/packages/webreel/src/commands/record.ts
+++ b/packages/webreel/src/commands/record.ts
@@ -63,12 +63,7 @@ export const recordCommand = new Command("record")
   .description("Record videos")
   .argument("[videos...]", "Video names to record (default: all)")
   .option("-c, --config <path>", "Config file (repeatable)", accumulate, [])
-  .option(
-    "-p, --project <name>",
-    "Filter by project name/glob (repeatable)",
-    accumulate,
-    [],
-  )
+  .option("-f, --filter <name>", "Filter by video name/glob (repeatable)", accumulate, [])
   .option("--verbose", "Log each step as it executes")
   .option("--watch", "Re-record when config files change")
   .option("--dry-run", "Print the resolved config and step list without recording")
@@ -78,7 +73,7 @@ export const recordCommand = new Command("record")
       videoNames: string[],
       opts: {
         config: string[];
-        project: string[];
+        filter: string[];
         verbose?: boolean;
         watch?: boolean;
         dryRun?: boolean;
@@ -91,7 +86,7 @@ export const recordCommand = new Command("record")
       const verbose = opts.verbose ?? false;
 
       const fullConfig = await loadFullConfig(configPaths);
-      const videos = filterVideos(fullConfig.videos, videoNames, opts.project);
+      const videos = filterVideos(fullConfig.videos, videoNames, opts.filter);
 
       if (opts.dryRun) {
         printResolvedConfig(videos, fullConfig.videoSources);
@@ -141,7 +136,7 @@ export const recordCommand = new Command("record")
                 const updatedVideos = filterVideos(
                   latestConfig.videos,
                   videoNames,
-                  opts.project,
+                  opts.filter,
                 );
                 for (const video of updatedVideos) {
                   await runVideo(video, {

--- a/packages/webreel/src/commands/validate.ts
+++ b/packages/webreel/src/commands/validate.ts
@@ -1,57 +1,86 @@
 import { Command } from "commander";
 import { readFileSync } from "node:fs";
-import { basename, extname } from "node:path";
+import { basename, extname, relative } from "node:path";
 import { parse as parseJsonc } from "jsonc-parser";
 import {
-  resolveConfigPath,
+  resolveConfigPaths,
   validateWebreelConfig,
   parseSchemaVersion,
   formatValidationErrors,
   buildLineMap,
+  loadFullConfig,
   loadWebreelConfig,
 } from "../lib/config.js";
 
 const JSON_EXTENSIONS = new Set([".json"]);
 
-export const validateCommand = new Command("validate")
-  .description("Validate a webreel config file")
-  .option("-c, --config <path>", "Path to config file (default: webreel.config.json)")
-  .action(async (opts: { config?: string }) => {
-    const configPath = resolveConfigPath(opts.config);
-    const name = basename(configPath);
-    const ext = extname(configPath);
+function accumulate(val: string, prev: string[]): string[] {
+  return [...prev, val];
+}
 
-    if (JSON_EXTENSIONS.has(ext)) {
-      const raw = readFileSync(configPath, "utf-8");
-      let parsed: unknown;
+export const validateCommand = new Command("validate")
+  .description("Validate webreel config file(s)")
+  .option("-c, --config <path>", "Config file (repeatable)", accumulate, [])
+  .action(async (opts: { config: string[] }) => {
+    const configPaths = await resolveConfigPaths(
+      opts.config.length > 0 ? opts.config : undefined,
+    );
+
+    const errors: string[] = [];
+
+    for (const configPath of configPaths) {
+      const name = basename(configPath);
+      const ext = extname(configPath);
+
       try {
-        parsed = parseJsonc(raw);
+        if (JSON_EXTENSIONS.has(ext)) {
+          const raw = readFileSync(configPath, "utf-8");
+          let parsed: unknown;
+          try {
+            parsed = parseJsonc(raw);
+          } catch (err) {
+            errors.push(
+              `${name}: invalid JSON - ${err instanceof Error ? err.message : String(err)}`,
+            );
+            continue;
+          }
+
+          const schemaUrl =
+            typeof parsed === "object" && parsed !== null
+              ? (parsed as Record<string, unknown>).$schema
+              : undefined;
+          const version = parseSchemaVersion(
+            typeof schemaUrl === "string" ? schemaUrl : undefined,
+          );
+          const validationErrors = validateWebreelConfig(parsed, version);
+
+          if (validationErrors.length > 0) {
+            const lineMap = buildLineMap(raw);
+            errors.push(formatValidationErrors(name, validationErrors, lineMap));
+          } else {
+            console.log(`${name}: valid`);
+          }
+        } else {
+          await loadWebreelConfig(configPath);
+          console.log(`${name}: valid`);
+        }
       } catch (err) {
-        throw new Error(
-          `${name}: invalid JSON - ${err instanceof Error ? err.message : String(err)}`,
-          {
-            cause: err,
-          },
+        errors.push(
+          `${relative(process.cwd(), configPath)}: ${err instanceof Error ? err.message : String(err)}`,
         );
       }
+    }
 
-      const schemaUrl =
-        typeof parsed === "object" && parsed !== null
-          ? (parsed as Record<string, unknown>).$schema
-          : undefined;
-      const version = parseSchemaVersion(
-        typeof schemaUrl === "string" ? schemaUrl : undefined,
-      );
-      const errors = validateWebreelConfig(parsed, version);
-
-      if (errors.length === 0) {
-        console.log(`${name}: valid`);
-      } else {
-        const lineMap = buildLineMap(raw);
-        throw new Error(formatValidationErrors(name, errors, lineMap));
+    if (configPaths.length > 1) {
+      try {
+        const full = await loadFullConfig(configPaths);
+        console.log(`Cross-config: ${full.videos.length} video(s), no duplicates`);
+      } catch (err) {
+        errors.push(`Cross-config: ${err instanceof Error ? err.message : String(err)}`);
       }
-    } else {
-      await loadWebreelConfig(configPath);
-      console.log(`${name}: valid`);
+    }
+
+    if (errors.length > 0) {
+      throw new Error(errors.join("\n\n"));
     }
   });

--- a/packages/webreel/src/commands/validate.ts
+++ b/packages/webreel/src/commands/validate.ts
@@ -57,9 +57,11 @@ export const validateCommand = new Command("validate")
           if (validationErrors.length > 0) {
             const lineMap = buildLineMap(raw);
             errors.push(formatValidationErrors(name, validationErrors, lineMap));
-          } else {
-            console.log(`${name}: valid`);
+            continue;
           }
+
+          await loadWebreelConfig(configPath);
+          console.log(`${name}: valid`);
         } else {
           await loadWebreelConfig(configPath);
           console.log(`${name}: valid`);

--- a/packages/webreel/src/config.ts
+++ b/packages/webreel/src/config.ts
@@ -1,6 +1,7 @@
 export type {
   WebreelConfig,
   VideoConfig,
+  FullConfig,
   Step,
   StepPause,
   StepClick,
@@ -21,10 +22,21 @@ export type {
 
 export { VIEWPORT_PRESETS } from "./lib/types.js";
 
-export type InputVideoConfig = Omit<import("./lib/types.js").VideoConfig, "name">;
+export {
+  loadWebreelConfig,
+  loadFullConfig,
+  resolveConfigPath,
+  resolveConfigPaths,
+  filterVideosByName,
+} from "./lib/config.js";
 
-export interface InputWebreelConfig {
-  $schema?: string;
+export type InputVideoConfig = Omit<
+  import("./lib/types.js").VideoConfig,
+  "name" | "configDir"
+>;
+
+export interface InputScenarioConfig {
+  extends?: boolean | string;
   outDir?: string;
   baseUrl?: string;
   viewport?: string | { width: number; height: number };
@@ -36,6 +48,25 @@ export interface InputWebreelConfig {
   videos: Record<string, InputVideoConfig>;
 }
 
+export interface InputWebreelConfig {
+  $schema?: string;
+  extends?: string;
+  outDir?: string;
+  baseUrl?: string;
+  viewport?: string | { width: number; height: number };
+  theme?: import("./lib/types.js").ThemeConfig;
+  sfx?: import("./lib/types.js").SfxConfig;
+  include?: string[];
+  defaultDelay?: number;
+  clickDwell?: number;
+  scenarios?: (string | InputScenarioConfig)[];
+  videos?: Record<string, InputVideoConfig>;
+}
+
 export function defineConfig(config: InputWebreelConfig): InputWebreelConfig {
+  return config;
+}
+
+export function defineScenario(config: InputScenarioConfig): InputScenarioConfig {
   return config;
 }

--- a/packages/webreel/src/index.ts
+++ b/packages/webreel/src/index.ts
@@ -9,6 +9,7 @@ import { initCommand } from "./commands/init.js";
 import { validateCommand } from "./commands/validate.js";
 import { previewCommand } from "./commands/preview.js";
 import { compositeCommand } from "./commands/composite.js";
+import { listCommand } from "./commands/list.js";
 import { installCommand } from "./commands/install.js";
 
 let version = "0.0.0";
@@ -35,6 +36,7 @@ program.addCommand(initCommand);
 program.addCommand(validateCommand);
 program.addCommand(previewCommand);
 program.addCommand(compositeCommand);
+program.addCommand(listCommand);
 program.addCommand(installCommand);
 
 program.parseAsync().catch((err: Error) => {

--- a/packages/webreel/src/lib/__tests__/config.test.ts
+++ b/packages/webreel/src/lib/__tests__/config.test.ts
@@ -1,13 +1,17 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import {
   validateWebreelConfig,
   loadWebreelConfig,
+  loadFullConfig,
+  resolveConfigPaths,
   parseSchemaVersion,
   resolveConfigPath,
   formatValidationErrors,
   buildLineMap,
   getConfigDir,
   filterVideosByName,
+  filterVideosByProject,
+  filterVideos,
   type ValidationError,
 } from "../config.js";
 import type { VideoConfig } from "../types.js";
@@ -685,6 +689,272 @@ describe("filterVideosByName", () => {
   });
 });
 
+describe("extends resolution", () => {
+  const dir = resolve(tmpdir(), `webreel-extends-test-${Date.now()}`);
+
+  function cleanup() {
+    try {
+      rmSync(dir, { recursive: true, force: true });
+    } catch {
+      // ignore
+    }
+  }
+
+  it("inherits top-level defaults from base config", async () => {
+    mkdirSync(dir, { recursive: true });
+    try {
+      writeFileSync(
+        resolve(dir, "base.json"),
+        JSON.stringify({
+          baseUrl: "https://base.com",
+          viewport: { width: 1920, height: 1080 },
+          defaultDelay: 300,
+          videos: {},
+        }),
+      );
+      writeFileSync(
+        resolve(dir, "child.json"),
+        JSON.stringify({
+          extends: "./base.json",
+          videos: {
+            hero: { url: "/", steps: [] },
+          },
+        }),
+      );
+      const config = await loadWebreelConfig(resolve(dir, "child.json"));
+      expect(config.baseUrl).toBe("https://base.com");
+      expect(config.viewport).toEqual({ width: 1920, height: 1080 });
+      expect(config.defaultDelay).toBe(300);
+      expect(config.videos).toHaveLength(1);
+      expect(config.videos[0].name).toBe("hero");
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("child overrides base top-level values", async () => {
+    mkdirSync(dir, { recursive: true });
+    try {
+      writeFileSync(
+        resolve(dir, "base.json"),
+        JSON.stringify({
+          baseUrl: "https://base.com",
+          defaultDelay: 300,
+          videos: {},
+        }),
+      );
+      writeFileSync(
+        resolve(dir, "child.json"),
+        JSON.stringify({
+          extends: "./base.json",
+          baseUrl: "https://child.com",
+          videos: {
+            hero: { url: "/", steps: [] },
+          },
+        }),
+      );
+      const config = await loadWebreelConfig(resolve(dir, "child.json"));
+      expect(config.baseUrl).toBe("https://child.com");
+      expect(config.defaultDelay).toBe(300);
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("inherits videos from base config", async () => {
+    mkdirSync(dir, { recursive: true });
+    try {
+      writeFileSync(
+        resolve(dir, "base.json"),
+        JSON.stringify({
+          videos: {
+            base_video: { url: "https://example.com", steps: [] },
+          },
+        }),
+      );
+      writeFileSync(
+        resolve(dir, "child.json"),
+        JSON.stringify({
+          extends: "./base.json",
+          videos: {
+            child_video: { url: "https://example.com/child", steps: [] },
+          },
+        }),
+      );
+      const config = await loadWebreelConfig(resolve(dir, "child.json"));
+      expect(config.videos).toHaveLength(2);
+      const names = config.videos.map((v) => v.name).sort();
+      expect(names).toEqual(["base_video", "child_video"]);
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("child video overrides base video with same name", async () => {
+    mkdirSync(dir, { recursive: true });
+    try {
+      writeFileSync(
+        resolve(dir, "base.json"),
+        JSON.stringify({
+          videos: {
+            hero: { url: "https://base.com", steps: [] },
+          },
+        }),
+      );
+      writeFileSync(
+        resolve(dir, "child.json"),
+        JSON.stringify({
+          extends: "./base.json",
+          videos: {
+            hero: { url: "https://child.com", steps: [] },
+          },
+        }),
+      );
+      const config = await loadWebreelConfig(resolve(dir, "child.json"));
+      expect(config.videos).toHaveLength(1);
+      expect(config.videos[0].url).toBe("https://child.com");
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("supports chained extends (3 levels)", async () => {
+    mkdirSync(dir, { recursive: true });
+    try {
+      writeFileSync(
+        resolve(dir, "grandparent.json"),
+        JSON.stringify({
+          baseUrl: "https://gp.com",
+          videos: {},
+        }),
+      );
+      writeFileSync(
+        resolve(dir, "parent.json"),
+        JSON.stringify({
+          extends: "./grandparent.json",
+          defaultDelay: 500,
+          videos: {},
+        }),
+      );
+      writeFileSync(
+        resolve(dir, "child.json"),
+        JSON.stringify({
+          extends: "./parent.json",
+          videos: { hero: { url: "/", steps: [] } },
+        }),
+      );
+      const config = await loadWebreelConfig(resolve(dir, "child.json"));
+      expect(config.baseUrl).toBe("https://gp.com");
+      expect(config.defaultDelay).toBe(500);
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("detects circular extends", async () => {
+    mkdirSync(dir, { recursive: true });
+    try {
+      writeFileSync(
+        resolve(dir, "a.json"),
+        JSON.stringify({ extends: "./b.json", videos: { x: { url: "u", steps: [] } } }),
+      );
+      writeFileSync(
+        resolve(dir, "b.json"),
+        JSON.stringify({ extends: "./a.json", videos: { x: { url: "u", steps: [] } } }),
+      );
+      await expect(loadWebreelConfig(resolve(dir, "a.json"))).rejects.toThrow("Circular");
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("throws on missing extends target", async () => {
+    mkdirSync(dir, { recursive: true });
+    try {
+      writeFileSync(
+        resolve(dir, "child.json"),
+        JSON.stringify({
+          extends: "./nonexistent.json",
+          videos: { x: { url: "u", steps: [] } },
+        }),
+      );
+      await expect(loadWebreelConfig(resolve(dir, "child.json"))).rejects.toThrow(
+        "not found",
+      );
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("rejects extends: true in file-based config", async () => {
+    mkdirSync(dir, { recursive: true });
+    try {
+      writeFileSync(
+        resolve(dir, "child.json"),
+        JSON.stringify({
+          extends: true,
+          videos: { x: { url: "u", steps: [] } },
+        }),
+      );
+      await expect(loadWebreelConfig(resolve(dir, "child.json"))).rejects.toThrow(
+        "only valid in inline scenario",
+      );
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("shallow-merges theme sub-keys", async () => {
+    mkdirSync(dir, { recursive: true });
+    try {
+      writeFileSync(
+        resolve(dir, "base.json"),
+        JSON.stringify({
+          theme: {
+            cursor: { size: 32, hotspot: "top-left" },
+            hud: { background: "black" },
+          },
+          videos: {},
+        }),
+      );
+      writeFileSync(
+        resolve(dir, "child.json"),
+        JSON.stringify({
+          extends: "./base.json",
+          theme: {
+            cursor: { size: 48 },
+            hud: { color: "white" },
+          },
+          videos: { hero: { url: "/", steps: [] } },
+        }),
+      );
+      const config = await loadWebreelConfig(resolve(dir, "child.json"));
+      expect(config.theme?.cursor).toEqual({ size: 48, hotspot: "top-left" });
+      expect(config.theme?.hud).toEqual({ background: "black", color: "white" });
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("returned config does not contain extends field", async () => {
+    mkdirSync(dir, { recursive: true });
+    try {
+      writeFileSync(resolve(dir, "base.json"), JSON.stringify({ videos: {} }));
+      writeFileSync(
+        resolve(dir, "child.json"),
+        JSON.stringify({
+          extends: "./base.json",
+          videos: { hero: { url: "/", steps: [] } },
+        }),
+      );
+      const config = await loadWebreelConfig(resolve(dir, "child.json"));
+      expect("extends" in config).toBe(false);
+    } finally {
+      cleanup();
+    }
+  });
+});
+
 describe("loadWebreelConfig with env substitution", () => {
   const dir = resolve(tmpdir(), `webreel-env-test-${Date.now()}`);
 
@@ -722,5 +992,616 @@ describe("loadWebreelConfig with env substitution", () => {
       }
       cleanup();
     }
+  });
+});
+
+describe("scenarios and loadFullConfig", () => {
+  const dir = resolve(tmpdir(), `webreel-scenarios-test-${Date.now()}`);
+
+  function cleanup() {
+    try {
+      rmSync(dir, { recursive: true, force: true });
+    } catch {
+      // ignore
+    }
+  }
+
+  it("loads config with scenarios glob", async () => {
+    const demos = resolve(dir, "demos");
+    mkdirSync(demos, { recursive: true });
+    try {
+      writeFileSync(
+        resolve(demos, "login.webreel.json"),
+        JSON.stringify({
+          videos: { login: { url: "/login", steps: [] } },
+        }),
+      );
+      writeFileSync(
+        resolve(dir, "webreel.config.json"),
+        JSON.stringify({
+          scenarios: ["./demos/*.webreel.json"],
+          videos: { hero: { url: "/", steps: [] } },
+        }),
+      );
+      const full = await loadFullConfig([resolve(dir, "webreel.config.json")]);
+      expect(full.videos).toHaveLength(2);
+      const names = full.videos.map((v) => v.name).sort();
+      expect(names).toEqual(["hero", "login"]);
+      expect(full.videoSources.get("hero")).toContain("webreel.config.json");
+      expect(full.videoSources.get("login")).toContain("login.webreel.json");
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("loads config with inline scenario extends: true", async () => {
+    mkdirSync(dir, { recursive: true });
+    try {
+      writeFileSync(
+        resolve(dir, "webreel.config.json"),
+        JSON.stringify({
+          baseUrl: "https://example.com",
+          defaultDelay: 400,
+          scenarios: [
+            {
+              extends: true,
+              videos: { login: { url: "/login", steps: [] } },
+            },
+          ],
+          videos: { hero: { url: "/", steps: [] } },
+        }),
+      );
+      const full = await loadFullConfig([resolve(dir, "webreel.config.json")]);
+      expect(full.videos).toHaveLength(2);
+      const login = full.videos.find((v) => v.name === "login")!;
+      expect(login.baseUrl).toBe("https://example.com");
+      expect(login.defaultDelay).toBe(400);
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("loads config with inline scenario standalone", async () => {
+    mkdirSync(dir, { recursive: true });
+    try {
+      writeFileSync(
+        resolve(dir, "webreel.config.json"),
+        JSON.stringify({
+          baseUrl: "https://root.com",
+          scenarios: [
+            {
+              baseUrl: "https://standalone.com",
+              videos: { login: { url: "/login", steps: [] } },
+            },
+          ],
+          videos: { hero: { url: "/", steps: [] } },
+        }),
+      );
+      const full = await loadFullConfig([resolve(dir, "webreel.config.json")]);
+      const login = full.videos.find((v) => v.name === "login")!;
+      expect(login.baseUrl).toBe("https://standalone.com");
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("detects duplicate video names across configs", async () => {
+    const demos = resolve(dir, "demos");
+    mkdirSync(demos, { recursive: true });
+    try {
+      writeFileSync(
+        resolve(demos, "dup.webreel.json"),
+        JSON.stringify({
+          videos: { hero: { url: "/dup", steps: [] } },
+        }),
+      );
+      writeFileSync(
+        resolve(dir, "webreel.config.json"),
+        JSON.stringify({
+          scenarios: ["./demos/*.webreel.json"],
+          videos: { hero: { url: "/", steps: [] } },
+        }),
+      );
+      await expect(loadFullConfig([resolve(dir, "webreel.config.json")])).rejects.toThrow(
+        "Duplicate video name",
+      );
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("allows config with only scenarios and no videos", async () => {
+    const demos = resolve(dir, "demos");
+    mkdirSync(demos, { recursive: true });
+    try {
+      writeFileSync(
+        resolve(demos, "a.webreel.json"),
+        JSON.stringify({
+          videos: { demo: { url: "/demo", steps: [] } },
+        }),
+      );
+      writeFileSync(
+        resolve(dir, "webreel.config.json"),
+        JSON.stringify({
+          scenarios: ["./demos/*.webreel.json"],
+        }),
+      );
+      const full = await loadFullConfig([resolve(dir, "webreel.config.json")]);
+      expect(full.videos).toHaveLength(1);
+      expect(full.videos[0].name).toBe("demo");
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("numbers inline scenarios in videoSources", async () => {
+    mkdirSync(dir, { recursive: true });
+    try {
+      writeFileSync(
+        resolve(dir, "webreel.config.json"),
+        JSON.stringify({
+          scenarios: [
+            { videos: { a: { url: "/a", steps: [] } } },
+            { videos: { b: { url: "/b", steps: [] } } },
+          ],
+        }),
+      );
+      const full = await loadFullConfig([resolve(dir, "webreel.config.json")]);
+      expect(full.videoSources.get("a")).toContain("[scenario #1]");
+      expect(full.videoSources.get("b")).toContain("[scenario #2]");
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("loads multiple configs via loadFullConfig", async () => {
+    const dirA = resolve(dir, "a");
+    const dirB = resolve(dir, "b");
+    mkdirSync(dirA, { recursive: true });
+    mkdirSync(dirB, { recursive: true });
+    try {
+      writeFileSync(
+        resolve(dirA, "webreel.config.json"),
+        JSON.stringify({ videos: { alpha: { url: "/a", steps: [] } } }),
+      );
+      writeFileSync(
+        resolve(dirB, "webreel.config.json"),
+        JSON.stringify({ videos: { beta: { url: "/b", steps: [] } } }),
+      );
+      const full = await loadFullConfig([
+        resolve(dirA, "webreel.config.json"),
+        resolve(dirB, "webreel.config.json"),
+      ]);
+      expect(full.videos).toHaveLength(2);
+      const names = full.videos.map((v) => v.name).sort();
+      expect(names).toEqual(["alpha", "beta"]);
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("validates scenarios in validateWebreelConfig", () => {
+    const errors = validateWebreelConfig({
+      scenarios: [{ videos: { x: { url: "u", steps: [] } } }, "./demos/*.json"],
+    });
+    expect(errors).toEqual([]);
+  });
+
+  it("rejects scenarios with invalid elements", () => {
+    const errors = validateWebreelConfig({
+      scenarios: [123],
+      videos: { x: { url: "u", steps: [] } },
+    });
+    expect(errors.length).toBeGreaterThan(0);
+    expect(errors[0].path).toContain("scenarios[0]");
+  });
+
+  it("rejects inline scenario without videos", () => {
+    const errors = validateWebreelConfig({
+      scenarios: [{ baseUrl: "https://example.com" }],
+    });
+    expect(errors.length).toBeGreaterThan(0);
+    expect(errors[0].path).toContain("scenarios[0].videos");
+  });
+});
+
+describe("filterVideosByProject", () => {
+  const videos: VideoConfig[] = [
+    { name: "hero", url: "/", steps: [], configDir: "/tmp" },
+    { name: "login", url: "/login", steps: [], configDir: "/tmp" },
+    { name: "signup", url: "/signup", steps: [], configDir: "/tmp" },
+    { name: "dashboard-light", url: "/dash", steps: [], configDir: "/tmp" },
+    { name: "dashboard-dark", url: "/dash-dark", steps: [], configDir: "/tmp" },
+  ] as VideoConfig[];
+
+  it("returns all with empty patterns", () => {
+    expect(filterVideosByProject(videos, [])).toEqual(videos);
+  });
+
+  it("filters by exact name", () => {
+    const result = filterVideosByProject(videos, ["hero"]);
+    expect(result.map((v) => v.name)).toEqual(["hero"]);
+  });
+
+  it("filters by glob pattern", () => {
+    const result = filterVideosByProject(videos, ["dashboard-*"]);
+    expect(result.map((v) => v.name)).toEqual(["dashboard-light", "dashboard-dark"]);
+  });
+
+  it("throws on missing exact name", () => {
+    expect(() => filterVideosByProject(videos, ["nonexistent"])).toThrow(
+      "Project(s) not found",
+    );
+  });
+
+  it("does not throw on empty glob match", () => {
+    expect(() => filterVideosByProject(videos, ["nothing*"])).toThrow(
+      "No videos matched",
+    );
+  });
+
+  it("combines exact and glob", () => {
+    const result = filterVideosByProject(videos, ["hero", "dashboard-*"]);
+    expect(result.map((v) => v.name)).toEqual([
+      "hero",
+      "dashboard-light",
+      "dashboard-dark",
+    ]);
+  });
+});
+
+describe("filterVideos (union)", () => {
+  const videos: VideoConfig[] = [
+    { name: "hero", url: "/", steps: [], configDir: "/tmp" },
+    { name: "login", url: "/login", steps: [], configDir: "/tmp" },
+    { name: "signup", url: "/signup", steps: [], configDir: "/tmp" },
+  ] as VideoConfig[];
+
+  it("returns all with empty filters", () => {
+    expect(filterVideos(videos, [], [])).toEqual(videos);
+  });
+
+  it("union of names and projects", () => {
+    const result = filterVideos(videos, ["hero"], ["login"]);
+    expect(result.map((v) => v.name)).toEqual(["hero", "login"]);
+  });
+
+  it("deduplicates overlapping filters", () => {
+    const result = filterVideos(videos, ["hero"], ["hero"]);
+    expect(result.map((v) => v.name)).toEqual(["hero"]);
+  });
+});
+
+describe("defineConfig and defineScenario", () => {
+  it("defineConfig returns the same object", async () => {
+    const { defineConfig } = await import("../../config.js");
+    const input = {
+      baseUrl: "https://example.com",
+      videos: { hero: { url: "/", steps: [] } },
+    };
+    expect(defineConfig(input)).toBe(input);
+  });
+
+  it("defineScenario returns the same object", async () => {
+    const { defineScenario } = await import("../../config.js");
+    const input = {
+      extends: true as const,
+      videos: { hero: { url: "/", steps: [] } },
+    };
+    expect(defineScenario(input)).toBe(input);
+  });
+});
+
+describe("resolveConfigPaths", () => {
+  const dir = resolve(tmpdir(), `webreel-resolve-paths-test-${Date.now()}`);
+
+  function cleanup() {
+    try {
+      rmSync(dir, { recursive: true, force: true });
+    } catch {
+      // ignore
+    }
+  }
+
+  it("resolves explicit paths", async () => {
+    mkdirSync(dir, { recursive: true });
+    try {
+      writeFileSync(resolve(dir, "a.json"), JSON.stringify({ videos: {} }));
+      writeFileSync(resolve(dir, "b.json"), JSON.stringify({ videos: {} }));
+      const paths = await resolveConfigPaths([
+        resolve(dir, "a.json"),
+        resolve(dir, "b.json"),
+      ]);
+      expect(paths).toHaveLength(2);
+      expect(paths[0]).toBe(resolve(dir, "a.json"));
+      expect(paths[1]).toBe(resolve(dir, "b.json"));
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("resolves glob patterns", async () => {
+    mkdirSync(dir, { recursive: true });
+    try {
+      writeFileSync(resolve(dir, "x.webreel.json"), "{}");
+      writeFileSync(resolve(dir, "y.webreel.json"), "{}");
+      const paths = await resolveConfigPaths([resolve(dir, "*.webreel.json")]);
+      expect(paths).toHaveLength(2);
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("throws on missing explicit path", async () => {
+    await expect(resolveConfigPaths([resolve(dir, "nonexistent.json")])).rejects.toThrow(
+      "not found",
+    );
+  });
+
+  it("throws on glob with no matches", async () => {
+    mkdirSync(dir, { recursive: true });
+    try {
+      await expect(resolveConfigPaths([resolve(dir, "*.nope.json")])).rejects.toThrow(
+        "No config files matched",
+      );
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("deduplicates paths", async () => {
+    mkdirSync(dir, { recursive: true });
+    try {
+      writeFileSync(resolve(dir, "a.json"), "{}");
+      const paths = await resolveConfigPaths([
+        resolve(dir, "a.json"),
+        resolve(dir, "a.json"),
+      ]);
+      expect(paths).toHaveLength(1);
+    } finally {
+      cleanup();
+    }
+  });
+});
+
+describe("inline scenario with file extends", () => {
+  const dir = resolve(tmpdir(), `webreel-scenario-file-extends-${Date.now()}`);
+
+  function cleanup() {
+    try {
+      rmSync(dir, { recursive: true, force: true });
+    } catch {
+      // ignore
+    }
+  }
+
+  it("inline scenario extends a file path", async () => {
+    mkdirSync(dir, { recursive: true });
+    try {
+      writeFileSync(
+        resolve(dir, "base.json"),
+        JSON.stringify({
+          baseUrl: "https://base.com",
+          defaultDelay: 300,
+          videos: {},
+        }),
+      );
+      writeFileSync(
+        resolve(dir, "root.json"),
+        JSON.stringify({
+          scenarios: [
+            {
+              extends: "./base.json",
+              videos: { demo: { url: "/demo", steps: [] } },
+            },
+          ],
+        }),
+      );
+      const full = await loadFullConfig([resolve(dir, "root.json")]);
+      expect(full.videos).toHaveLength(1);
+      expect(full.videos[0].name).toBe("demo");
+      expect(full.videos[0].baseUrl).toBe("https://base.com");
+      expect(full.videos[0].defaultDelay).toBe(300);
+    } finally {
+      cleanup();
+    }
+  });
+});
+
+describe("nested scenarios warning", () => {
+  const dir = resolve(tmpdir(), `webreel-nested-scenarios-${Date.now()}`);
+
+  function cleanup() {
+    try {
+      rmSync(dir, { recursive: true, force: true });
+    } catch {
+      // ignore
+    }
+  }
+
+  it("warns and ignores nested scenarios", async () => {
+    const subdir = resolve(dir, "sub");
+    mkdirSync(subdir, { recursive: true });
+    try {
+      writeFileSync(
+        resolve(subdir, "child.webreel.json"),
+        JSON.stringify({
+          scenarios: ["./nonexistent/*.json"],
+          videos: { nested: { url: "/nested", steps: [] } },
+        }),
+      );
+      writeFileSync(
+        resolve(dir, "root.json"),
+        JSON.stringify({
+          scenarios: ["./sub/*.webreel.json"],
+        }),
+      );
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      try {
+        const full = await loadFullConfig([resolve(dir, "root.json")]);
+        expect(full.videos).toHaveLength(1);
+        expect(full.videos[0].name).toBe("nested");
+        expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("scenarios"));
+      } finally {
+        warnSpy.mockRestore();
+      }
+    } finally {
+      cleanup();
+    }
+  });
+});
+
+describe("loadFullConfig duplicate between root and scenario", () => {
+  const dir = resolve(tmpdir(), `webreel-dup-root-scenario-${Date.now()}`);
+
+  function cleanup() {
+    try {
+      rmSync(dir, { recursive: true, force: true });
+    } catch {
+      // ignore
+    }
+  }
+
+  it("detects duplicate between root videos and scenario videos", async () => {
+    mkdirSync(dir, { recursive: true });
+    try {
+      writeFileSync(
+        resolve(dir, "root.json"),
+        JSON.stringify({
+          scenarios: [{ videos: { hero: { url: "/inline", steps: [] } } }],
+          videos: { hero: { url: "/root", steps: [] } },
+        }),
+      );
+      await expect(loadFullConfig([resolve(dir, "root.json")])).rejects.toThrow(
+        "Duplicate video name",
+      );
+    } finally {
+      cleanup();
+    }
+  });
+});
+
+describe("TS config with defineConfig and defineScenario", () => {
+  it("loads TS config with defineConfig", async () => {
+    const dir = resolve(
+      tmpdir(),
+      `webreel-ts-simple-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    );
+    mkdirSync(dir, { recursive: true });
+    try {
+      writeFileSync(
+        resolve(dir, "webreel.config.ts"),
+        `export default {
+          baseUrl: "https://ts-test.com",
+          videos: {
+            demo: { url: "/demo", steps: [{ action: "pause", ms: 100 }] },
+          },
+        };`,
+      );
+      const config = await loadWebreelConfig(resolve(dir, "webreel.config.ts"));
+      expect(config.videos).toHaveLength(1);
+      expect(config.videos[0].name).toBe("demo");
+      expect(config.baseUrl).toBe("https://ts-test.com");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("loads TS config with scenarios glob and inline extends", async () => {
+    const dir = resolve(
+      tmpdir(),
+      `webreel-ts-scenarios-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    );
+    const scenariosDir = resolve(dir, "scenarios");
+    mkdirSync(scenariosDir, { recursive: true });
+    try {
+      writeFileSync(
+        resolve(scenariosDir, "extra.webreel.json"),
+        JSON.stringify({
+          videos: {
+            "glob-video": { url: "https://example.com/glob", steps: [] },
+          },
+        }),
+      );
+      writeFileSync(
+        resolve(dir, "webreel.config.ts"),
+        `export default {
+          baseUrl: "https://root.com",
+          viewport: { width: 1920, height: 1080 },
+          scenarios: [
+            "./scenarios/*.webreel.json",
+            {
+              extends: true,
+              videos: {
+                "inline-video": { url: "/inline", steps: [] },
+              },
+            },
+          ],
+          videos: {
+            root: { url: "/root", steps: [] },
+          },
+        };`,
+      );
+      const full = await loadFullConfig([resolve(dir, "webreel.config.ts")]);
+      expect(full.videos).toHaveLength(3);
+      const names = full.videos.map((v) => v.name).sort();
+      expect(names).toEqual(["glob-video", "inline-video", "root"]);
+
+      const inlineVideo = full.videos.find((v) => v.name === "inline-video")!;
+      expect(inlineVideo.baseUrl).toBe("https://root.com");
+      expect(inlineVideo.viewport).toEqual({ width: 1920, height: 1080 });
+
+      expect(full.videoSources.get("root")).toContain("webreel.config.ts");
+      expect(full.videoSources.get("glob-video")).toContain("extra.webreel.json");
+      expect(full.videoSources.get("inline-video")).toContain("[scenario #1]");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("loads TS config with extends", async () => {
+    const dir = resolve(
+      tmpdir(),
+      `webreel-ts-extends-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    );
+    mkdirSync(dir, { recursive: true });
+    try {
+      writeFileSync(
+        resolve(dir, "base.json"),
+        JSON.stringify({
+          baseUrl: "https://base.com",
+          defaultDelay: 250,
+          videos: {},
+        }),
+      );
+      writeFileSync(
+        resolve(dir, "child.ts"),
+        `export default {
+          extends: "./base.json",
+          videos: {
+            child: { url: "/child", steps: [] },
+          },
+        };`,
+      );
+      const config = await loadWebreelConfig(resolve(dir, "child.ts"));
+      expect(config.baseUrl).toBe("https://base.com");
+      expect(config.defaultDelay).toBe(250);
+      expect(config.videos).toHaveLength(1);
+      expect(config.videos[0].name).toBe("child");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("FullConfig public type export", () => {
+  it("FullConfig is importable from config.ts", async () => {
+    const mod = await import("../../config.js");
+    expect(mod.loadFullConfig).toBeTypeOf("function");
+    expect(mod.resolveConfigPaths).toBeTypeOf("function");
+    expect(mod.loadWebreelConfig).toBeTypeOf("function");
+    expect(mod.filterVideosByName).toBeTypeOf("function");
+    expect(mod.defineConfig).toBeTypeOf("function");
+    expect(mod.defineScenario).toBeTypeOf("function");
   });
 });

--- a/packages/webreel/src/lib/__tests__/config.test.ts
+++ b/packages/webreel/src/lib/__tests__/config.test.ts
@@ -10,7 +10,7 @@ import {
   buildLineMap,
   getConfigDir,
   filterVideosByName,
-  filterVideosByProject,
+  filterVideosByPattern,
   filterVideos,
   type ValidationError,
 } from "../config.js";
@@ -886,6 +886,24 @@ describe("extends resolution", () => {
     }
   });
 
+  it("rejects broken extends path during full resolution", async () => {
+    mkdirSync(dir, { recursive: true });
+    try {
+      writeFileSync(
+        resolve(dir, "broken.json"),
+        JSON.stringify({
+          extends: "./nonexistent-base.json",
+          videos: { hero: { url: "/", steps: [] } },
+        }),
+      );
+      await expect(loadWebreelConfig(resolve(dir, "broken.json"))).rejects.toThrow(
+        "not found",
+      );
+    } finally {
+      cleanup();
+    }
+  });
+
   it("rejects extends: true in file-based config", async () => {
     mkdirSync(dir, { recursive: true });
     try {
@@ -1205,7 +1223,7 @@ describe("scenarios and loadFullConfig", () => {
   });
 });
 
-describe("filterVideosByProject", () => {
+describe("filterVideosByPattern", () => {
   const videos: VideoConfig[] = [
     { name: "hero", url: "/", steps: [], configDir: "/tmp" },
     { name: "login", url: "/login", steps: [], configDir: "/tmp" },
@@ -1215,33 +1233,33 @@ describe("filterVideosByProject", () => {
   ] as VideoConfig[];
 
   it("returns all with empty patterns", () => {
-    expect(filterVideosByProject(videos, [])).toEqual(videos);
+    expect(filterVideosByPattern(videos, [])).toEqual(videos);
   });
 
   it("filters by exact name", () => {
-    const result = filterVideosByProject(videos, ["hero"]);
+    const result = filterVideosByPattern(videos, ["hero"]);
     expect(result.map((v) => v.name)).toEqual(["hero"]);
   });
 
   it("filters by glob pattern", () => {
-    const result = filterVideosByProject(videos, ["dashboard-*"]);
+    const result = filterVideosByPattern(videos, ["dashboard-*"]);
     expect(result.map((v) => v.name)).toEqual(["dashboard-light", "dashboard-dark"]);
   });
 
   it("throws on missing exact name", () => {
-    expect(() => filterVideosByProject(videos, ["nonexistent"])).toThrow(
-      "Project(s) not found",
+    expect(() => filterVideosByPattern(videos, ["nonexistent"])).toThrow(
+      "Pattern(s) not found",
     );
   });
 
   it("does not throw on empty glob match", () => {
-    expect(() => filterVideosByProject(videos, ["nothing*"])).toThrow(
+    expect(() => filterVideosByPattern(videos, ["nothing*"])).toThrow(
       "No videos matched",
     );
   });
 
   it("combines exact and glob", () => {
-    const result = filterVideosByProject(videos, ["hero", "dashboard-*"]);
+    const result = filterVideosByPattern(videos, ["hero", "dashboard-*"]);
     expect(result.map((v) => v.name)).toEqual([
       "hero",
       "dashboard-light",
@@ -1261,7 +1279,7 @@ describe("filterVideos (union)", () => {
     expect(filterVideos(videos, [], [])).toEqual(videos);
   });
 
-  it("union of names and projects", () => {
+  it("union of names and patterns", () => {
     const result = filterVideos(videos, ["hero"], ["login"]);
     expect(result.map((v) => v.name)).toEqual(["hero", "login"]);
   });

--- a/packages/webreel/src/lib/__tests__/config.test.ts
+++ b/packages/webreel/src/lib/__tests__/config.test.ts
@@ -1408,6 +1408,53 @@ describe("inline scenario with file extends", () => {
   });
 });
 
+describe("inline scenario extends: true inherits from root extends chain", () => {
+  const dir = resolve(
+    tmpdir(),
+    `webreel-scenario-root-extends-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  );
+
+  function cleanup() {
+    try {
+      rmSync(dir, { recursive: true, force: true });
+    } catch {
+      // ignore
+    }
+  }
+
+  it("inline scenario with extends: true sees values from root extends", async () => {
+    mkdirSync(dir, { recursive: true });
+    try {
+      writeFileSync(
+        resolve(dir, "base.json"),
+        JSON.stringify({
+          baseUrl: "https://from-base.com",
+          defaultDelay: 999,
+          videos: {},
+        }),
+      );
+      writeFileSync(
+        resolve(dir, "root.json"),
+        JSON.stringify({
+          extends: "./base.json",
+          scenarios: [
+            {
+              extends: true,
+              videos: { demo: { url: "/demo", steps: [] } },
+            },
+          ],
+        }),
+      );
+      const full = await loadFullConfig([resolve(dir, "root.json")]);
+      expect(full.videos).toHaveLength(1);
+      expect(full.videos[0].baseUrl).toBe("https://from-base.com");
+      expect(full.videos[0].defaultDelay).toBe(999);
+    } finally {
+      cleanup();
+    }
+  });
+});
+
 describe("nested scenarios warning", () => {
   const dir = resolve(tmpdir(), `webreel-nested-scenarios-${Date.now()}`);
 

--- a/packages/webreel/src/lib/config.ts
+++ b/packages/webreel/src/lib/config.ts
@@ -1,8 +1,10 @@
 import { readFileSync, existsSync } from "node:fs";
-import { resolve, dirname, isAbsolute, extname } from "node:path";
+import { resolve, dirname, isAbsolute, extname, relative } from "node:path";
 import { parse as parseJsonc, parseTree, getNodePath } from "jsonc-parser";
 import { createJiti } from "jiti";
-import type { VideoConfig, WebreelConfig } from "./types.js";
+import { glob, isDynamicPattern } from "tinyglobby";
+import picomatch from "picomatch";
+import type { VideoConfig, WebreelConfig, FullConfig } from "./types.js";
 import { VIEWPORT_PRESETS } from "./types.js";
 
 export const DEFAULT_CONFIG_NAME = "webreel.config";
@@ -51,7 +53,10 @@ async function resolveIncludes(
       parsed = parseJsonc(raw) as Record<string, unknown>;
     } else {
       try {
-        const mod = await loadTsConfig(absPath);
+        let mod = await loadTsConfig(absPath);
+        if (typeof mod === "object" && mod !== null && "default" in mod) {
+          mod = (mod as Record<string, unknown>).default;
+        }
         if (typeof mod !== "object" || mod === null) {
           throw new Error(`Include file must export an object: ${absPath}`);
         }
@@ -155,28 +160,202 @@ function substituteEnvVars(obj: unknown): unknown {
   return obj;
 }
 
+const MAX_EXTENDS_DEPTH = 10;
+
+const MERGEABLE_TOP_LEVEL_KEYS = [
+  "baseUrl",
+  "viewport",
+  "outDir",
+  "include",
+  "defaultDelay",
+  "clickDwell",
+] as const;
+
+function mergeTheme(
+  base: Record<string, unknown> | undefined,
+  child: Record<string, unknown> | undefined,
+): Record<string, unknown> | undefined {
+  if (!base && !child) return undefined;
+  if (!base) return child;
+  if (!child) return base;
+  const merged: Record<string, unknown> = {};
+  const allKeys = new Set([...Object.keys(base), ...Object.keys(child)]);
+  for (const key of allKeys) {
+    const bVal = base[key];
+    const cVal = child[key];
+    if (
+      typeof bVal === "object" &&
+      bVal !== null &&
+      typeof cVal === "object" &&
+      cVal !== null
+    ) {
+      merged[key] = { ...bVal, ...cVal };
+    } else {
+      merged[key] = cVal !== undefined ? cVal : bVal;
+    }
+  }
+  return merged;
+}
+
+function mergeSfx(
+  base: Record<string, unknown> | undefined,
+  child: Record<string, unknown> | undefined,
+): Record<string, unknown> | undefined {
+  if (!base && !child) return undefined;
+  if (!base) return child;
+  if (!child) return base;
+  return { ...base, ...child };
+}
+
+async function loadRawConfig(filePath: string): Promise<Record<string, unknown>> {
+  const ext = extname(filePath);
+  if (JSON_EXTENSIONS.has(ext)) {
+    const raw = readFileSync(filePath, "utf-8");
+    return substituteEnvVars(parseJsonc(raw)) as Record<string, unknown>;
+  }
+  let mod = await loadTsConfig(filePath);
+  if (typeof mod === "object" && mod !== null && "default" in mod) {
+    mod = (mod as Record<string, unknown>).default;
+  }
+  if (typeof mod !== "object" || mod === null) {
+    throw new Error(`Config file must export an object: ${filePath}`);
+  }
+  return substituteEnvVars(mod) as Record<string, unknown>;
+}
+
+async function resolveExtends(
+  parsed: Record<string, unknown>,
+  filePath: string,
+  seen: Set<string>,
+  depth: number,
+): Promise<Record<string, unknown>> {
+  const extendsValue = parsed.extends;
+  if (extendsValue === undefined) return parsed;
+
+  if (extendsValue === true) {
+    throw new Error(
+      `"extends: true" is only valid in inline scenario configs. Use a file path instead. (in ${filePath})`,
+    );
+  }
+
+  if (typeof extendsValue !== "string" || extendsValue.length === 0) {
+    throw new Error(`"extends" must be a non-empty string (in ${filePath})`);
+  }
+
+  if (depth >= MAX_EXTENDS_DEPTH) {
+    throw new Error(`"extends" chain too deep (max ${MAX_EXTENDS_DEPTH})`);
+  }
+
+  const baseDir = dirname(resolve(filePath));
+  const basePath = resolve(baseDir, extendsValue);
+
+  if (!existsSync(basePath)) {
+    throw new Error(
+      `"extends" target not found: ${extendsValue} (referenced from ${resolve(filePath)})`,
+    );
+  }
+
+  const absBasePath = resolve(basePath);
+  if (seen.has(absBasePath)) {
+    const chain = [...seen, absBasePath].join(" -> ");
+    throw new Error(`Circular "extends" detected: ${chain}`);
+  }
+  seen.add(absBasePath);
+
+  let baseParsed = await loadRawConfig(absBasePath);
+  baseParsed = await resolveExtends(baseParsed, absBasePath, seen, depth + 1);
+
+  const baseIncludeDir = dirname(absBasePath);
+  if (Array.isArray(baseParsed.include)) {
+    baseParsed.include = baseParsed.include.map((inc: unknown) =>
+      typeof inc === "string" && !isAbsolute(inc) ? resolve(baseIncludeDir, inc) : inc,
+    );
+  }
+
+  const merged: Record<string, unknown> = {};
+
+  for (const key of MERGEABLE_TOP_LEVEL_KEYS) {
+    if (baseParsed[key] !== undefined) merged[key] = baseParsed[key];
+  }
+
+  merged.theme = mergeTheme(
+    baseParsed.theme as Record<string, unknown> | undefined,
+    parsed.theme as Record<string, unknown> | undefined,
+  );
+  merged.sfx = mergeSfx(
+    baseParsed.sfx as Record<string, unknown> | undefined,
+    parsed.sfx as Record<string, unknown> | undefined,
+  );
+
+  for (const key of MERGEABLE_TOP_LEVEL_KEYS) {
+    if (parsed[key] !== undefined) merged[key] = parsed[key];
+  }
+
+  if (parsed.include !== undefined) {
+    const childDir = dirname(resolve(filePath));
+    merged.include = (parsed.include as unknown[]).map((inc: unknown) =>
+      typeof inc === "string" && !isAbsolute(inc) ? resolve(childDir, inc) : inc,
+    );
+  }
+
+  const baseVideos =
+    baseParsed.videos != null &&
+    typeof baseParsed.videos === "object" &&
+    !Array.isArray(baseParsed.videos)
+      ? { ...(baseParsed.videos as Record<string, unknown>) }
+      : {};
+
+  const childVideos =
+    parsed.videos != null &&
+    typeof parsed.videos === "object" &&
+    !Array.isArray(parsed.videos)
+      ? (parsed.videos as Record<string, unknown>)
+      : {};
+
+  const mergedVideos = { ...baseVideos, ...childVideos };
+
+  return {
+    ...merged,
+    $schema: parsed.$schema,
+    videos: Object.keys(mergedVideos).length > 0 ? mergedVideos : undefined,
+    scenarios: parsed.scenarios,
+  };
+}
+
 async function buildConfigFromParsed(
   parsed: Record<string, unknown>,
   filePath: string,
 ): Promise<WebreelConfig> {
-  if (
-    !parsed.videos ||
-    typeof parsed.videos !== "object" ||
-    Array.isArray(parsed.videos)
-  ) {
-    throw new Error(`Config must contain a "videos" object`);
+  const resolved = await resolveExtends(
+    parsed,
+    filePath,
+    new Set([resolve(filePath)]),
+    0,
+  );
+
+  const hasVideos =
+    resolved.videos != null &&
+    typeof resolved.videos === "object" &&
+    !Array.isArray(resolved.videos);
+  const hasScenarios = Array.isArray(resolved.scenarios) && resolved.scenarios.length > 0;
+
+  if (!hasVideos && !hasScenarios) {
+    throw new Error(`Config must contain a "videos" object or a "scenarios" array`);
   }
-  const videosObj = parsed.videos as Record<string, Record<string, unknown>>;
+
+  const videosObj = hasVideos
+    ? (resolved.videos as Record<string, Record<string, unknown>>)
+    : {};
   const configDir = dirname(resolve(filePath));
-  const outDir = resolve(configDir, (parsed.outDir as string) ?? "videos");
+  const outDir = resolve(configDir, (resolved.outDir as string) ?? "videos");
   const defaults = {
-    baseUrl: parsed.baseUrl as string | undefined,
-    viewport: resolveViewportValue(parsed.viewport),
-    theme: parsed.theme as WebreelConfig["theme"],
-    sfx: parsed.sfx as WebreelConfig["sfx"],
-    include: parsed.include as string[] | undefined,
-    defaultDelay: parsed.defaultDelay as number | undefined,
-    clickDwell: parsed.clickDwell as number | undefined,
+    baseUrl: resolved.baseUrl as string | undefined,
+    viewport: resolveViewportValue(resolved.viewport),
+    theme: resolved.theme as WebreelConfig["theme"],
+    sfx: resolved.sfx as WebreelConfig["sfx"],
+    include: resolved.include as string[] | undefined,
+    defaultDelay: resolved.defaultDelay as number | undefined,
+    clickDwell: resolved.clickDwell as number | undefined,
   };
 
   const videoList: VideoConfig[] = [];
@@ -186,21 +365,21 @@ async function buildConfigFromParsed(
       videoBody.viewport =
         resolveViewportPreset(videoBody.viewport as string) ?? videoBody.viewport;
     }
-    const video = { ...videoBody, name } as unknown as VideoConfig;
-    const resolved = resolveVideoDefaults(video, defaults, outDir, configDir);
-    videoList.push(await resolveVideo(resolved, filePath));
+    const video = { ...videoBody, name, configDir } as unknown as VideoConfig;
+    const resolvedVideo = resolveVideoDefaults(video, defaults, outDir, configDir);
+    videoList.push(await resolveVideo(resolvedVideo, filePath));
   }
 
   return {
-    $schema: parsed.$schema as string | undefined,
-    outDir: parsed.outDir as string | undefined,
-    baseUrl: parsed.baseUrl as string | undefined,
-    viewport: resolveViewportValue(parsed.viewport),
-    theme: parsed.theme as WebreelConfig["theme"],
-    sfx: parsed.sfx as WebreelConfig["sfx"],
-    include: parsed.include as string[] | undefined,
-    defaultDelay: parsed.defaultDelay as number | undefined,
-    clickDwell: parsed.clickDwell as number | undefined,
+    $schema: resolved.$schema as string | undefined,
+    outDir: resolved.outDir as string | undefined,
+    baseUrl: resolved.baseUrl as string | undefined,
+    viewport: resolveViewportValue(resolved.viewport),
+    theme: resolved.theme as WebreelConfig["theme"],
+    sfx: resolved.sfx as WebreelConfig["sfx"],
+    include: resolved.include as string[] | undefined,
+    defaultDelay: resolved.defaultDelay as number | undefined,
+    clickDwell: resolved.clickDwell as number | undefined,
     videos: videoList,
   };
 }
@@ -228,7 +407,11 @@ export async function loadWebreelConfig(filePath: string): Promise<WebreelConfig
     return buildConfigFromParsed(parsed as Record<string, unknown>, filePath);
   }
 
-  const raw = await loadTsConfig(filePath);
+  let raw = await loadTsConfig(filePath);
+
+  if (typeof raw === "object" && raw !== null && "default" in raw) {
+    raw = (raw as Record<string, unknown>).default;
+  }
 
   if (typeof raw !== "object" || raw === null) {
     throw new Error(`Config file must export an object: ${filePath}`);
@@ -294,6 +477,7 @@ const VALID_ACTIONS = new Set([
 
 const KNOWN_TOP_LEVEL_KEYS = new Set([
   "$schema",
+  "extends",
   "outDir",
   "baseUrl",
   "viewport",
@@ -302,6 +486,7 @@ const KNOWN_TOP_LEVEL_KEYS = new Set([
   "include",
   "defaultDelay",
   "clickDwell",
+  "scenarios",
   "videos",
 ]);
 
@@ -803,6 +988,118 @@ function validateTheme(theme: unknown, prefix: string): ValidationError[] {
   return errors;
 }
 
+const KNOWN_SCENARIO_KEYS = new Set([
+  "extends",
+  "outDir",
+  "baseUrl",
+  "viewport",
+  "theme",
+  "sfx",
+  "include",
+  "defaultDelay",
+  "clickDwell",
+  "videos",
+]);
+
+function validateScenarios(scenarios: unknown, prefix: string): ValidationError[] {
+  const errors: ValidationError[] = [];
+  if (!Array.isArray(scenarios)) {
+    errors.push({ path: prefix, message: "Must be an array" });
+    return errors;
+  }
+  for (let i = 0; i < scenarios.length; i++) {
+    const item = scenarios[i];
+    const itemPath = `${prefix}[${i}]`;
+
+    if (typeof item === "string") {
+      if (item.length === 0) {
+        errors.push({ path: itemPath, message: "Must be a non-empty string" });
+      }
+      continue;
+    }
+
+    if (typeof item !== "object" || item === null) {
+      errors.push({
+        path: itemPath,
+        message: "Must be a glob string or an inline scenario object",
+      });
+      continue;
+    }
+
+    const s = item as Record<string, unknown>;
+
+    errors.push(...checkUnknownKeys(s, KNOWN_SCENARIO_KEYS, itemPath));
+
+    if (s.extends !== undefined) {
+      if (
+        typeof s.extends !== "boolean" &&
+        (typeof s.extends !== "string" || s.extends.length === 0)
+      ) {
+        errors.push({
+          path: `${itemPath}.extends`,
+          message: "Must be true, false, or a non-empty string",
+        });
+      }
+    }
+
+    if (
+      s.videos === undefined ||
+      s.videos === null ||
+      typeof s.videos !== "object" ||
+      Array.isArray(s.videos)
+    ) {
+      errors.push({
+        path: `${itemPath}.videos`,
+        message: "Required, must be an object mapping names to video configs",
+      });
+      continue;
+    }
+
+    const scenarioVideos = s.videos as Record<string, unknown>;
+    for (const [name, video] of Object.entries(scenarioVideos)) {
+      const vPrefix = `${itemPath}.videos.${name}`;
+      if (typeof video !== "object" || video === null) {
+        errors.push({ path: vPrefix, message: "Must be a video config object" });
+        continue;
+      }
+      const d = video as Record<string, unknown>;
+      errors.push(...checkUnknownKeys(d, KNOWN_VIDEO_KEYS, vPrefix));
+      if (typeof d.url !== "string" || d.url.length === 0) {
+        errors.push({
+          path: `${vPrefix}.url`,
+          message: "Required, must be a non-empty string",
+        });
+      }
+      if (!Array.isArray(d.steps)) {
+        errors.push({ path: `${vPrefix}.steps`, message: "Required, must be an array" });
+      } else {
+        for (let j = 0; j < d.steps.length; j++) {
+          errors.push(
+            ...validateStep(d.steps[j], j).map((e) => ({
+              ...e,
+              path: `${vPrefix}.${e.path}`,
+            })),
+          );
+        }
+      }
+    }
+
+    if (s.viewport !== undefined) {
+      errors.push(...validateViewport(s.viewport, `${itemPath}.viewport`));
+    }
+    if (s.theme !== undefined) {
+      errors.push(...validateTheme(s.theme, `${itemPath}.theme`));
+    }
+    if (s.sfx !== undefined) {
+      errors.push(...validateSfx(s.sfx, `${itemPath}.sfx`));
+    }
+    if (s.include !== undefined) {
+      errors.push(...validateInclude(s.include, `${itemPath}.include`));
+    }
+  }
+  return errors;
+}
+
 export function validateWebreelConfig(
   config: unknown,
   version: number = CURRENT_SCHEMA_VERSION,
@@ -826,6 +1123,20 @@ export function validateWebreelConfig(
   const c = config as Record<string, unknown>;
 
   errors.push(...checkUnknownKeys(c, KNOWN_TOP_LEVEL_KEYS, ""));
+
+  if (c.extends !== undefined) {
+    if (typeof c.extends === "boolean") {
+      if (c.extends !== true) {
+        errors.push({ path: "extends", message: "Must be true or a non-empty string" });
+      }
+    } else if (typeof c.extends !== "string" || c.extends.length === 0) {
+      errors.push({ path: "extends", message: "Must be true or a non-empty string" });
+    }
+  }
+
+  if (c.scenarios !== undefined) {
+    errors.push(...validateScenarios(c.scenarios, "scenarios"));
+  }
 
   if (c.outDir !== undefined && (typeof c.outDir !== "string" || c.outDir.length === 0)) {
     errors.push({ path: "outDir", message: "Must be a non-empty string" });
@@ -865,15 +1176,22 @@ export function validateWebreelConfig(
     errors.push(...validateSfx(c.sfx, "sfx"));
   }
 
-  if (
-    c.videos === undefined ||
-    c.videos === null ||
-    typeof c.videos !== "object" ||
-    Array.isArray(c.videos)
-  ) {
+  const hasScenarios = Array.isArray(c.scenarios) && c.scenarios.length > 0;
+
+  if (c.videos === undefined || c.videos === null) {
+    if (!hasScenarios) {
+      errors.push({
+        path: "videos",
+        message: "Required, must be an object mapping names to video configs",
+      });
+    }
+    return errors;
+  }
+
+  if (typeof c.videos !== "object" || Array.isArray(c.videos)) {
     errors.push({
       path: "videos",
-      message: "Required, must be an object mapping names to video configs",
+      message: "Must be an object mapping names to video configs",
     });
     return errors;
   }
@@ -881,7 +1199,7 @@ export function validateWebreelConfig(
   const videos = c.videos as Record<string, unknown>;
   const names = Object.keys(videos);
 
-  if (names.length === 0) {
+  if (names.length === 0 && !hasScenarios) {
     errors.push({ path: "videos", message: "Must contain at least one video" });
   }
 
@@ -1124,6 +1442,66 @@ export function filterVideosByName(
   return filtered;
 }
 
+export function filterVideosByProject(
+  videos: VideoConfig[],
+  patterns: string[],
+): VideoConfig[] {
+  if (patterns.length === 0) return videos;
+
+  const result = new Set<string>();
+  const exactMissing: string[] = [];
+
+  for (const pattern of patterns) {
+    if (isDynamicPattern(pattern)) {
+      const matcher = picomatch(pattern);
+      for (const v of videos) {
+        if (matcher(v.name)) result.add(v.name);
+      }
+    } else {
+      const found = videos.find((v) => v.name === pattern);
+      if (found) {
+        result.add(found.name);
+      } else {
+        exactMissing.push(pattern);
+      }
+    }
+  }
+
+  if (exactMissing.length > 0) {
+    const available = videos.map((v) => v.name).join(", ");
+    throw new Error(
+      `Project(s) not found: ${exactMissing.join(", ")}. Available: ${available}`,
+    );
+  }
+
+  if (result.size === 0) {
+    throw new Error(`No videos matched --project patterns: ${patterns.join(", ")}`);
+  }
+
+  return videos.filter((v) => result.has(v.name));
+}
+
+export function filterVideos(
+  videos: VideoConfig[],
+  names: string[],
+  projects: string[],
+): VideoConfig[] {
+  if (names.length === 0 && projects.length === 0) return videos;
+  if (names.length > 0 && projects.length === 0) return filterVideosByName(videos, names);
+  if (names.length === 0 && projects.length > 0)
+    return filterVideosByProject(videos, projects);
+
+  const byName = new Set(filterVideosByName(videos, names).map((v) => v.name));
+  const byProject = new Set(filterVideosByProject(videos, projects).map((v) => v.name));
+  const union = new Set([...byName, ...byProject]);
+
+  if (union.size === 0) {
+    throw new Error("No videos matched the given filters.");
+  }
+
+  return videos.filter((v) => union.has(v.name));
+}
+
 export function resolveConfigPath(configPath?: string): string {
   if (configPath) {
     const resolved = resolve(configPath);
@@ -1152,4 +1530,225 @@ export function resolveConfigPath(configPath?: string): string {
   throw new Error(
     `No config file found. Create a ${DEFAULT_CONFIG_FILE} or specify one with --config.`,
   );
+}
+
+export async function resolveConfigPaths(configOpt?: string[]): Promise<string[]> {
+  if (!configOpt || configOpt.length === 0) {
+    return [resolveConfigPath()];
+  }
+
+  const resolved = new Set<string>();
+
+  for (const pattern of configOpt) {
+    if (isDynamicPattern(pattern)) {
+      const matches = await glob([pattern], {
+        cwd: process.cwd(),
+        absolute: true,
+      });
+      if (matches.length === 0) {
+        throw new Error(`No config files matched: "${pattern}"`);
+      }
+      for (const m of matches) resolved.add(resolve(m));
+    } else {
+      const abs = resolve(pattern);
+      if (!existsSync(abs)) {
+        throw new Error(`Config file not found: ${abs}`);
+      }
+      resolved.add(abs);
+    }
+  }
+
+  if (resolved.size === 0) {
+    throw new Error("No config files found.");
+  }
+
+  return [...resolved];
+}
+
+async function resolveScenarios(
+  rootParsed: Record<string, unknown>,
+  configPath: string,
+): Promise<{ videos: VideoConfig[]; sources: Map<string, string> }> {
+  const scenarios = rootParsed.scenarios;
+  if (!Array.isArray(scenarios) || scenarios.length === 0) {
+    return { videos: [], sources: new Map() };
+  }
+
+  const configDir = dirname(resolve(configPath));
+  const relConfigPath = relative(process.cwd(), resolve(configPath));
+  const allVideos: VideoConfig[] = [];
+  const sources = new Map<string, string>();
+  const loadedPaths = new Set<string>();
+  const errors: string[] = [];
+  let scenarioIndex = 0;
+
+  for (const item of scenarios) {
+    if (typeof item === "string") {
+      const matches = await glob([item], {
+        cwd: configDir,
+        absolute: true,
+      });
+      for (const matchPath of matches) {
+        const abs = resolve(matchPath);
+        if (loadedPaths.has(abs)) continue;
+        loadedPaths.add(abs);
+
+        try {
+          const childConfig = await loadWebreelConfig(abs);
+
+          const childRaw = await loadRawConfig(abs);
+          if (Array.isArray(childRaw.scenarios) && childRaw.scenarios.length > 0) {
+            console.warn(
+              `Warning: "scenarios" in ${relative(process.cwd(), abs)} ignored (nested scenarios not supported)`,
+            );
+          }
+
+          const relChild = relative(process.cwd(), abs);
+          for (const video of childConfig.videos) {
+            sources.set(video.name, relChild);
+            allVideos.push(video);
+          }
+        } catch (err) {
+          errors.push(
+            `${relative(process.cwd(), abs)}: ${err instanceof Error ? err.message : String(err)}`,
+          );
+        }
+      }
+      continue;
+    }
+
+    if (typeof item === "object" && item !== null) {
+      scenarioIndex++;
+      const scenario = item as Record<string, unknown>;
+      const sourceLabel = `${relConfigPath} [scenario #${scenarioIndex}]`;
+
+      let scenarioParsed: Record<string, unknown>;
+
+      if (scenario.extends === true) {
+        scenarioParsed = { ...scenario };
+        delete scenarioParsed.extends;
+
+        for (const key of MERGEABLE_TOP_LEVEL_KEYS) {
+          if (scenarioParsed[key] === undefined && rootParsed[key] !== undefined) {
+            scenarioParsed[key] = rootParsed[key];
+          }
+        }
+        if (scenarioParsed.theme === undefined && rootParsed.theme !== undefined) {
+          scenarioParsed.theme = rootParsed.theme;
+        } else if (rootParsed.theme !== undefined) {
+          scenarioParsed.theme = mergeTheme(
+            rootParsed.theme as Record<string, unknown> | undefined,
+            scenarioParsed.theme as Record<string, unknown> | undefined,
+          );
+        }
+        if (scenarioParsed.sfx === undefined && rootParsed.sfx !== undefined) {
+          scenarioParsed.sfx = rootParsed.sfx;
+        } else if (rootParsed.sfx !== undefined) {
+          scenarioParsed.sfx = mergeSfx(
+            rootParsed.sfx as Record<string, unknown> | undefined,
+            scenarioParsed.sfx as Record<string, unknown> | undefined,
+          );
+        }
+      } else if (typeof scenario.extends === "string") {
+        scenarioParsed = await resolveExtends(
+          scenario,
+          configPath,
+          new Set([resolve(configPath)]),
+          0,
+        );
+      } else {
+        scenarioParsed = scenario;
+      }
+
+      if (
+        scenarioParsed.videos != null &&
+        typeof scenarioParsed.videos === "object" &&
+        !Array.isArray(scenarioParsed.videos)
+      ) {
+        const scenarioDir = configDir;
+        const outDir = resolve(
+          scenarioDir,
+          (scenarioParsed.outDir as string) ?? "videos",
+        );
+        const defaults = {
+          baseUrl: scenarioParsed.baseUrl as string | undefined,
+          viewport: resolveViewportValue(scenarioParsed.viewport),
+          theme: scenarioParsed.theme as WebreelConfig["theme"],
+          sfx: scenarioParsed.sfx as WebreelConfig["sfx"],
+          include: scenarioParsed.include as string[] | undefined,
+          defaultDelay: scenarioParsed.defaultDelay as number | undefined,
+          clickDwell: scenarioParsed.clickDwell as number | undefined,
+        };
+
+        const videosObj = scenarioParsed.videos as Record<
+          string,
+          Record<string, unknown>
+        >;
+        for (const [name, body] of Object.entries(videosObj)) {
+          const videoBody = { ...body };
+          if (typeof videoBody.viewport === "string") {
+            videoBody.viewport =
+              resolveViewportPreset(videoBody.viewport as string) ?? videoBody.viewport;
+          }
+          const video = {
+            ...videoBody,
+            name,
+            configDir: scenarioDir,
+          } as unknown as VideoConfig;
+          const resolvedVideo = resolveVideoDefaults(
+            video,
+            defaults,
+            outDir,
+            scenarioDir,
+          );
+          const finalVideo = await resolveVideo(resolvedVideo, configPath);
+          sources.set(name, sourceLabel);
+          allVideos.push(finalVideo);
+        }
+      }
+    }
+  }
+
+  if (errors.length > 0) {
+    throw new Error(`Failed to load scenario configs:\n  ${errors.join("\n  ")}`);
+  }
+
+  return { videos: allVideos, sources };
+}
+
+export async function loadFullConfig(paths: string[]): Promise<FullConfig> {
+  const allVideos: VideoConfig[] = [];
+  const videoSources = new Map<string, string>();
+
+  for (const configPath of paths) {
+    const config = await loadWebreelConfig(configPath);
+    const relPath = relative(process.cwd(), resolve(configPath));
+
+    for (const video of config.videos) {
+      if (videoSources.has(video.name)) {
+        throw new Error(
+          `Duplicate video name "${video.name}" in ${videoSources.get(video.name)} and ${relPath}`,
+        );
+      }
+      videoSources.set(video.name, relPath);
+      allVideos.push(video);
+    }
+
+    const raw = await loadRawConfig(configPath);
+    if (Array.isArray(raw.scenarios) && raw.scenarios.length > 0) {
+      const { videos: scenarioVideos, sources } = await resolveScenarios(raw, configPath);
+      for (const video of scenarioVideos) {
+        const source = sources.get(video.name) ?? relPath;
+        if (videoSources.has(video.name)) {
+          throw new Error(
+            `Duplicate video name "${video.name}" in ${videoSources.get(video.name)} and ${source}`,
+          );
+        }
+        videoSources.set(video.name, source);
+        allVideos.push(video);
+      }
+    }
+  }
+
+  return { videos: allVideos, videoSources };
 }

--- a/packages/webreel/src/lib/config.ts
+++ b/packages/webreel/src/lib/config.ts
@@ -1735,8 +1735,17 @@ export async function loadFullConfig(paths: string[]): Promise<FullConfig> {
     }
 
     const raw = await loadRawConfig(configPath);
-    if (Array.isArray(raw.scenarios) && raw.scenarios.length > 0) {
-      const { videos: scenarioVideos, sources } = await resolveScenarios(raw, configPath);
+    const resolved = await resolveExtends(
+      raw,
+      configPath,
+      new Set([resolve(configPath)]),
+      0,
+    );
+    if (Array.isArray(resolved.scenarios) && resolved.scenarios.length > 0) {
+      const { videos: scenarioVideos, sources } = await resolveScenarios(
+        resolved,
+        configPath,
+      );
       for (const video of scenarioVideos) {
         const source = sources.get(video.name) ?? relPath;
         if (videoSources.has(video.name)) {

--- a/packages/webreel/src/lib/config.ts
+++ b/packages/webreel/src/lib/config.ts
@@ -322,10 +322,15 @@ async function resolveExtends(
   };
 }
 
+interface BuildResult {
+  config: WebreelConfig;
+  resolved: Record<string, unknown>;
+}
+
 async function buildConfigFromParsed(
   parsed: Record<string, unknown>,
   filePath: string,
-): Promise<WebreelConfig> {
+): Promise<BuildResult> {
   const resolved = await resolveExtends(
     parsed,
     filePath,
@@ -370,7 +375,7 @@ async function buildConfigFromParsed(
     videoList.push(await resolveVideo(resolvedVideo, filePath));
   }
 
-  return {
+  const config: WebreelConfig = {
     $schema: resolved.$schema as string | undefined,
     outDir: resolved.outDir as string | undefined,
     baseUrl: resolved.baseUrl as string | undefined,
@@ -382,9 +387,11 @@ async function buildConfigFromParsed(
     clickDwell: resolved.clickDwell as number | undefined,
     videos: videoList,
   };
+
+  return { config, resolved };
 }
 
-export async function loadWebreelConfig(filePath: string): Promise<WebreelConfig> {
+async function loadWebreelConfigFull(filePath: string): Promise<BuildResult> {
   const ext = extname(filePath);
 
   if (JSON_EXTENSIONS.has(ext)) {
@@ -424,6 +431,11 @@ export async function loadWebreelConfig(filePath: string): Promise<WebreelConfig
   }
 
   return buildConfigFromParsed(rawConfig, filePath);
+}
+
+export async function loadWebreelConfig(filePath: string): Promise<WebreelConfig> {
+  const { config } = await loadWebreelConfigFull(filePath);
+  return config;
 }
 
 async function resolveVideo(video: VideoConfig, filePath: string): Promise<VideoConfig> {
@@ -1442,7 +1454,7 @@ export function filterVideosByName(
   return filtered;
 }
 
-export function filterVideosByProject(
+export function filterVideosByPattern(
   videos: VideoConfig[],
   patterns: string[],
 ): VideoConfig[] {
@@ -1470,12 +1482,12 @@ export function filterVideosByProject(
   if (exactMissing.length > 0) {
     const available = videos.map((v) => v.name).join(", ");
     throw new Error(
-      `Project(s) not found: ${exactMissing.join(", ")}. Available: ${available}`,
+      `Pattern(s) not found: ${exactMissing.join(", ")}. Available: ${available}`,
     );
   }
 
   if (result.size === 0) {
-    throw new Error(`No videos matched --project patterns: ${patterns.join(", ")}`);
+    throw new Error(`No videos matched --filter patterns: ${patterns.join(", ")}`);
   }
 
   return videos.filter((v) => result.has(v.name));
@@ -1484,16 +1496,16 @@ export function filterVideosByProject(
 export function filterVideos(
   videos: VideoConfig[],
   names: string[],
-  projects: string[],
+  patterns: string[],
 ): VideoConfig[] {
-  if (names.length === 0 && projects.length === 0) return videos;
-  if (names.length > 0 && projects.length === 0) return filterVideosByName(videos, names);
-  if (names.length === 0 && projects.length > 0)
-    return filterVideosByProject(videos, projects);
+  if (names.length === 0 && patterns.length === 0) return videos;
+  if (names.length > 0 && patterns.length === 0) return filterVideosByName(videos, names);
+  if (names.length === 0 && patterns.length > 0)
+    return filterVideosByPattern(videos, patterns);
 
   const byName = new Set(filterVideosByName(videos, names).map((v) => v.name));
-  const byProject = new Set(filterVideosByProject(videos, projects).map((v) => v.name));
-  const union = new Set([...byName, ...byProject]);
+  const byPattern = new Set(filterVideosByPattern(videos, patterns).map((v) => v.name));
+  const union = new Set([...byName, ...byPattern]);
 
   if (union.size === 0) {
     throw new Error("No videos matched the given filters.");
@@ -1566,10 +1578,10 @@ export async function resolveConfigPaths(configOpt?: string[]): Promise<string[]
 }
 
 async function resolveScenarios(
-  rootParsed: Record<string, unknown>,
+  rootResolved: Record<string, unknown>,
   configPath: string,
 ): Promise<{ videos: VideoConfig[]; sources: Map<string, string> }> {
-  const scenarios = rootParsed.scenarios;
+  const scenarios = rootResolved.scenarios;
   if (!Array.isArray(scenarios) || scenarios.length === 0) {
     return { videos: [], sources: new Map() };
   }
@@ -1594,10 +1606,13 @@ async function resolveScenarios(
         loadedPaths.add(abs);
 
         try {
-          const childConfig = await loadWebreelConfig(abs);
+          const { config: childConfig, resolved: childResolved } =
+            await loadWebreelConfigFull(abs);
 
-          const childRaw = await loadRawConfig(abs);
-          if (Array.isArray(childRaw.scenarios) && childRaw.scenarios.length > 0) {
+          if (
+            Array.isArray(childResolved.scenarios) &&
+            childResolved.scenarios.length > 0
+          ) {
             console.warn(
               `Warning: "scenarios" in ${relative(process.cwd(), abs)} ignored (nested scenarios not supported)`,
             );
@@ -1629,23 +1644,23 @@ async function resolveScenarios(
         delete scenarioParsed.extends;
 
         for (const key of MERGEABLE_TOP_LEVEL_KEYS) {
-          if (scenarioParsed[key] === undefined && rootParsed[key] !== undefined) {
-            scenarioParsed[key] = rootParsed[key];
+          if (scenarioParsed[key] === undefined && rootResolved[key] !== undefined) {
+            scenarioParsed[key] = rootResolved[key];
           }
         }
-        if (scenarioParsed.theme === undefined && rootParsed.theme !== undefined) {
-          scenarioParsed.theme = rootParsed.theme;
-        } else if (rootParsed.theme !== undefined) {
+        if (scenarioParsed.theme === undefined && rootResolved.theme !== undefined) {
+          scenarioParsed.theme = rootResolved.theme;
+        } else if (rootResolved.theme !== undefined) {
           scenarioParsed.theme = mergeTheme(
-            rootParsed.theme as Record<string, unknown> | undefined,
+            rootResolved.theme as Record<string, unknown> | undefined,
             scenarioParsed.theme as Record<string, unknown> | undefined,
           );
         }
-        if (scenarioParsed.sfx === undefined && rootParsed.sfx !== undefined) {
-          scenarioParsed.sfx = rootParsed.sfx;
-        } else if (rootParsed.sfx !== undefined) {
+        if (scenarioParsed.sfx === undefined && rootResolved.sfx !== undefined) {
+          scenarioParsed.sfx = rootResolved.sfx;
+        } else if (rootResolved.sfx !== undefined) {
           scenarioParsed.sfx = mergeSfx(
-            rootParsed.sfx as Record<string, unknown> | undefined,
+            rootResolved.sfx as Record<string, unknown> | undefined,
             scenarioParsed.sfx as Record<string, unknown> | undefined,
           );
         }
@@ -1721,7 +1736,7 @@ export async function loadFullConfig(paths: string[]): Promise<FullConfig> {
   const videoSources = new Map<string, string>();
 
   for (const configPath of paths) {
-    const config = await loadWebreelConfig(configPath);
+    const { config, resolved } = await loadWebreelConfigFull(configPath);
     const relPath = relative(process.cwd(), resolve(configPath));
 
     for (const video of config.videos) {
@@ -1734,13 +1749,6 @@ export async function loadFullConfig(paths: string[]): Promise<FullConfig> {
       allVideos.push(video);
     }
 
-    const raw = await loadRawConfig(configPath);
-    const resolved = await resolveExtends(
-      raw,
-      configPath,
-      new Set([resolve(configPath)]),
-      0,
-    );
     if (Array.isArray(resolved.scenarios) && resolved.scenarios.length > 0) {
       const { videos: scenarioVideos, sources } = await resolveScenarios(
         resolved,

--- a/packages/webreel/src/lib/types.ts
+++ b/packages/webreel/src/lib/types.ts
@@ -174,6 +174,7 @@ import type { SfxConfig } from "@webreel/core";
 
 export interface VideoConfig {
   name: string;
+  configDir: string;
   url: string;
   baseUrl?: string;
   viewport?: { width: number; height: number };
@@ -202,4 +203,9 @@ export interface WebreelConfig {
   defaultDelay?: number;
   clickDwell?: number;
   videos: VideoConfig[];
+}
+
+export interface FullConfig {
+  videos: VideoConfig[];
+  videoSources: Map<string, string>;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -145,10 +145,19 @@ importers:
       jsonc-parser:
         specifier: ^3.3.1
         version: 3.3.1
+      picomatch:
+        specifier: ^4.0.3
+        version: 4.0.3
+      tinyglobby:
+        specifier: ^0.2.15
+        version: 0.2.15
     devDependencies:
       '@types/node':
         specifier: 25.3.0
         version: 25.3.0
+      '@types/picomatch':
+        specifier: ^4.0.2
+        version: 4.0.2
       typescript:
         specifier: 5.9.3
         version: 5.9.3
@@ -1156,6 +1165,9 @@ packages:
 
   '@types/node@25.3.0':
     resolution: {integrity: sha512-4K3bqJpXpqfg2XKGK9bpDTc6xO/xoUP/RBWS7AtRMug6zZFaRekiLzjVtAoZMquxoAbzBvy5nxQ7veS5eYzf8A==}
+
+  '@types/picomatch@4.0.2':
+    resolution: {integrity: sha512-qHHxQ+P9PysNEGbALT8f8YOSHW0KJu6l2xU8DYY0fu/EmGxXdVnuTLvFUvBgPJMSqXq29SYHveejeAha+4AYgA==}
 
   '@types/react-dom@19.2.3':
     resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
@@ -3566,6 +3578,8 @@ snapshots:
   '@types/node@25.3.0':
     dependencies:
       undici-types: 7.18.2
+
+  '@types/picomatch@4.0.2': {}
 
   '@types/react-dom@19.2.3(@types/react@19.2.14)':
     dependencies:


### PR DESCRIPTION
 Hi there again! In the project where we use webreel, the number of
   demo videos keeps growing. A single config becomes hard to manage,
   and there's no built-in way to run selective subsets in CI/CD
   pipelines.

   This PR is a working prototype of multi-config support. The goal is to
   start a conversation about the right API design for scaling webreel to
   bigger projects and automated pipelines. Everything here is open for
   discussion -- naming, semantics, the whole surface area.

   ## What the prototype includes

 ### Config: `extends`

   A config can inherit from a base file. Child values override base,
   theme and sfx get shallow sub-key merge, videos are combined. Chains
   work up to 10 levels deep, circular refs are detected.

   ```json
   // base.json
   {
     "baseUrl": "https://myapp.com",
     "viewport": "desktop",
     "defaultDelay": 500,
     "theme": { "cursor": { "size": 32, "hotspot": "top-left" } }
   }
 ```

 ```json
   // webreel.config.json — inherits baseUrl, viewport, defaultDelay
   // theme.cursor merges to { "size": 32, "hotspot": "center" }
   {
     "extends": "./base.json",
     "theme": { "cursor": { "hotspot": "center" } },
     "videos": {
       "hero": { "url": "/", "steps": [{ "action": "pause", "ms": 500 }] },
       "login": { "url": "/login", "steps": [{ "action": "pause", "ms": 500 }] }
     }
   }
 ```

### Config: scenarios

 Split videos across multiple files or inline groups. Entries can be
 glob strings (each matched file loaded as a standalone config) or
 inline objects with their own videos. extends: true on an inline
 scenario inherits top-level defaults from the root config. videos
 is optional when scenarios is present.

 ```json
   // webreel.config.json
   {
     "baseUrl": "https://myapp.com",
     "viewport": { "width": 1920, "height": 1080 },
     "scenarios": [
       "./demos/*.webreel.json",
       {
         "extends": true,
         "videos": {
           "inline-demo": { "url": "/demo", "steps": [] }
         }
       }
     ],
     "videos": {
       "hero": { "url": "/", "steps": [] }
     }
   }
 ```

 ```json
   // demos/login.webreel.json — discovered by glob
   {
     "videos": {
       "login": {
         "url": "https://myapp.com/login",
         "steps": [{ "action": "pause", "ms": 500 }]
       }
     }
   }
 ```

 TypeScript equivalent with defineScenario:

 ```ts
   import { defineConfig, defineScenario } from "webreel";

   export default defineConfig({
     baseUrl: "https://myapp.com",
     scenarios: [
       "./demos/*.webreel.ts",
       defineScenario({
         extends: true,
         videos: {
           login: { url: "/login", steps: [] },
         },
       }),
     ],
   });
 ```

### CLI: repeatable --config

 All commands (record, preview, composite, validate, list)
 now accept -c/--config multiple times to load several config files
 in one run. Glob patterns are supported.

 ```
   $ webreel record -c web.json -c mobile.json

   Recording: hero
   Done: videos/hero.mp4
   Recording: login
   Done: videos/login.mp4
   Recording: mobile-hero
   Done: videos/mobile-hero.mp4
   Recording: mobile-login
   Done: videos/mobile-login.mp4
 ```

 ```
   $ webreel record -c "configs/*.json"

   Recording: hero
   Done: videos/hero.mp4
   Recording: login
   Done: videos/login.mp4
 ```

### CLI: --project filtering

 -p/--project filters videos by exact name or glob pattern.
 Repeatable. Available on record, composite, and list. When
 combined with positional video names, results are unioned.

 ```
   # exact name
   $ webreel record -p hero

   Recording: hero
   Done: videos/hero.mp4
 ```

 ```
   # glob pattern
   $ webreel record -c web.json -c mobile.json -p "mobile-*"

   Recording: mobile-hero
   Done: videos/mobile-hero.mp4
   Recording: mobile-login
   Done: videos/mobile-login.mp4
 ```

 ```
   # multiple patterns
   $ webreel record -p hero -p "mobile-*"

   Recording: hero
   Done: videos/hero.mp4
   Recording: mobile-hero
   Done: videos/mobile-hero.mp4
   Recording: mobile-login
   Done: videos/mobile-login.mp4
 ```

 ```
   # union with positional names
   $ webreel record login -p "mobile-*"

   Recording: login
   Done: videos/login.mp4
   Recording: mobile-hero
   Done: videos/mobile-hero.mp4
   Recording: mobile-login
   Done: videos/mobile-login.mp4
 ```

### CLI: new webreel list command

 Lists all videos across configs with source file, URL, viewport, and
 step count. Supports --json for scripting and CI integration.

 ```
   $ webreel list

   3 video(s):

     hero (webreel.config.json)
       / 1920x1080 3 step(s)
     login (demos/login.webreel.json)
       /login 1920x1080 5 step(s)
     inline-demo (webreel.config.json [scenario #1])
       /demo 1920x1080 2 step(s)
 ```

 ```
   $ webreel list -c web.json -c mobile.json -p "mobile-*"

   2 video(s):

     mobile-hero (mobile.json)
       / 393x852 3 step(s)
     mobile-login (mobile.json)
       /login 393x852 5 step(s)
 ```

 ```
   $ webreel list --json

   [
     { "name": "hero", "url": "/", "source": "webreel.config.json", "steps": 3,
       "viewport": { "width": 1920, "height": 1080 }, "output": "videos/hero.mp4" },
     { "name": "login", "url": "/login", "source": "demos/login.webreel.json", "steps": 5,
       "viewport": { "width": 1920, "height": 1080 }, "output": "videos/login.mp4" }
   ]
 ```

### CLI: updated webreel validate

 Validates multiple configs and checks for duplicate video names across
 them.

 ```
   $ webreel validate -c web.json -c mobile.json

   web.json: valid
   mobile.json: valid
   Cross-config: 4 video(s), no duplicates
 ```

   ## Current state

   This is a proof of concept meant to explore the design space. The code
   works and is tested, but I'm sharing it early to align on direction
   before polishing. Backward compatibility with single-config usage is
   preserved, `loadWebreelConfig` return type is unchanged, `extends` and
   `scenarios` only exist on input types.

   ## Motivation

   Two main use cases drove this:

   1. **Large projects**: dozens of demo videos organized by feature,
      viewport, or theme. Splitting configs across files with shared
      defaults keeps things maintainable.
   2. **CI/CD**: running selective subsets of recordings per pipeline
      stage, filtering by pattern, validating across configs before
      recording.

   ## Looking for feedback on

   The entire API design is open. I'd love to hear your thoughts on how
   you envision multi-config support for webreel - naming conventions,
   config structure, CLI flags, public API surface, merge semantics,
   anything. Happy to rework this from scratch based on your vision for
   the project.
