### PR TITLE
fix: support SPA framework recording with `spa` config option

### DIFF
--- a/packages/@webreel/core/src/chrome.ts
+++ b/packages/@webreel/core/src/chrome.ts
@@ -194,13 +194,30 @@ const MAX_LAUNCH_ATTEMPTS = 3;
 
 export interface LaunchChromeOptions {
   headless?: boolean;
+  /**
+   * Use standard Chrome with `--headless=new` instead of chrome-headless-shell.
+   *
+   * Enable this when recording apps that use client-side routing (SPA
+   * frameworks like Next.js, Inertia.js, React Router, etc.). The default
+   * chrome-headless-shell binary uses `--enable-begin-frame-control` which
+   * freezes the compositor on DOM-only navigations — clicks that trigger
+   * client-side route changes produce stale video frames.
+   *
+   * Standard Chrome with `--headless=new` has the full rendering pipeline
+   * and correctly composites frames after SPA navigations.
+   *
+   * @default false
+   */
+  spa?: boolean;
 }
 
 export async function launchChrome(
   options?: LaunchChromeOptions,
 ): Promise<ChromeInstance> {
   const headless = options?.headless ?? true;
-  const chromePath = headless ? await ensureHeadlessShell() : await ensureChrome();
+  const spa = options?.spa ?? false;
+  const chromePath =
+    headless && !spa ? await ensureHeadlessShell() : await ensureChrome();
 
   let lastError: Error | null = null;
 
@@ -209,18 +226,28 @@ export async function launchChrome(
     const userDataDir = mkdtempSync(join(tmpdir(), "webreel-chrome-"));
 
     const args = headless
-      ? [
-          `--remote-debugging-port=${port}`,
-          `--user-data-dir=${userDataDir}`,
-          "--no-sandbox",
-          "--hide-scrollbars",
-          "--enable-begin-frame-control",
-          "--run-all-compositor-stages-before-draw",
-          "--disable-threaded-animation",
-          "--disable-threaded-scrolling",
-          "--disable-checker-imaging",
-          "about:blank",
-        ]
+      ? spa
+        ? [
+            "--headless=new",
+            `--remote-debugging-port=${port}`,
+            `--user-data-dir=${userDataDir}`,
+            "--no-sandbox",
+            "--hide-scrollbars",
+            "--disable-gpu",
+            "about:blank",
+          ]
+        : [
+            `--remote-debugging-port=${port}`,
+            `--user-data-dir=${userDataDir}`,
+            "--no-sandbox",
+            "--hide-scrollbars",
+            "--enable-begin-frame-control",
+            "--run-all-compositor-stages-before-draw",
+            "--disable-threaded-animation",
+            "--disable-threaded-scrolling",
+            "--disable-checker-imaging",
+            "about:blank",
+          ]
       : [
           `--remote-debugging-port=${port}`,
           `--user-data-dir=${userDataDir}`,

--- a/packages/@webreel/core/src/recorder.ts
+++ b/packages/@webreel/core/src/recorder.ts
@@ -174,14 +174,18 @@ export class Recorder {
           );
           if (!evalResult) break;
         }
-        const screenshotResult = await this.raceStop(
+        const screenshotResult = await Promise.race([
           client.Page.captureScreenshot({
             format: "jpeg",
             quality: 60,
             optimizeForSpeed: true,
           }),
-        );
-        if (!screenshotResult) break;
+          new Promise<null>((r) => setTimeout(() => r(null), 500)),
+        ]);
+        if (!screenshotResult) {
+          if (!this.running) break;
+          continue;
+        }
 
         const buffer = Buffer.from(screenshotResult.data, "base64");
         const now = Date.now();
@@ -208,6 +212,19 @@ export class Recorder {
         consecutiveErrors = 0;
       } catch (err) {
         if (!this.running) break;
+        const errMsg = err instanceof Error ? err.message : String(err);
+        // SPA frameworks (Inertia, Next.js, React Router) trigger client-side
+        // navigations that temporarily detach the CDP page target. Wait and
+        // retry instead of counting towards the abort threshold.
+        if (
+          errMsg.includes("Not attached") ||
+          errMsg.includes("Target closed") ||
+          errMsg.includes("Session closed") ||
+          errMsg.includes("Execution context")
+        ) {
+          await new Promise((r) => setTimeout(r, 100));
+          continue;
+        }
         consecutiveErrors++;
         if (consecutiveErrors >= 10) {
           console.error(

--- a/packages/webreel/src/lib/config.ts
+++ b/packages/webreel/src/lib/config.ts
@@ -92,7 +92,7 @@ function resolveVideoDefaults(
   defaults: Partial<
     Pick<
       WebreelConfig,
-      "baseUrl" | "viewport" | "theme" | "include" | "defaultDelay" | "clickDwell" | "sfx"
+      "baseUrl" | "viewport" | "theme" | "include" | "defaultDelay" | "clickDwell" | "sfx" | "spa"
     >
   >,
   outDir: string | undefined,
@@ -114,6 +114,8 @@ function resolveVideoDefaults(
     resolved.defaultDelay = defaults.defaultDelay;
   if (resolved.clickDwell === undefined && defaults.clickDwell !== undefined)
     resolved.clickDwell = defaults.clickDwell;
+  if (resolved.spa === undefined && defaults.spa !== undefined)
+    resolved.spa = defaults.spa;
   if (resolved.output && !isAbsolute(resolved.output) && outDir) {
     resolved.output = resolve(outDir, resolved.output);
   } else if (!resolved.output && outDir) {
@@ -177,6 +179,7 @@ async function buildConfigFromParsed(
     include: parsed.include as string[] | undefined,
     defaultDelay: parsed.defaultDelay as number | undefined,
     clickDwell: parsed.clickDwell as number | undefined,
+    spa: parsed.spa as boolean | undefined,
   };
 
   const videoList: VideoConfig[] = [];

--- a/packages/webreel/src/lib/runner.ts
+++ b/packages/webreel/src/lib/runner.ts
@@ -150,7 +150,7 @@ export async function runVideo(
   if (config.clickDwell !== undefined) ctx.setClickDwell(config.clickDwell);
   const initialCursor = ctx.getCursorPosition();
 
-  const chrome = await launchChrome({ headless: shouldRecord });
+  const chrome = await launchChrome({ headless: shouldRecord, spa: config.spa });
   let clientRef: CDPClient | null = null;
   let recorder: Recorder | null = null;
 

--- a/packages/webreel/src/lib/types.ts
+++ b/packages/webreel/src/lib/types.ts
@@ -188,6 +188,18 @@ export interface VideoConfig {
   sfx?: SfxConfig;
   defaultDelay?: number;
   clickDwell?: number;
+  /**
+   * Enable SPA-compatible recording mode.
+   *
+   * Uses standard Chrome with `--headless=new` instead of chrome-headless-shell.
+   * Required for apps that use client-side routing (Next.js, Inertia.js, React
+   * Router, SvelteKit, etc.) where clicks trigger DOM-based page transitions
+   * instead of full page loads.
+   *
+   * Without this, chrome-headless-shell's compositor freezes on SPA navigations,
+   * producing stale video frames after the first client-side route change.
+   */
+  spa?: boolean;
   steps: Step[];
 }
 
@@ -201,5 +213,7 @@ export interface WebreelConfig {
   include?: string[];
   defaultDelay?: number;
   clickDwell?: number;
+  /** Enable SPA-compatible recording mode globally. See `VideoConfig.spa`. */
+  spa?: boolean;
   videos: VideoConfig[];
 }


### PR DESCRIPTION
## Problem

When recording apps that use client-side routing the video freezes after the first SPA navigation. Steps execute correctly, screenshots capture the right pages, but the video only shows the first page.

### Root cause (3 issues)

| Issue | Location | Effect |
|-------|----------|--------|
| `chrome-headless-shell` + `--enable-begin-frame-control` | `chrome.ts` | Compositor freezes on DOM-only navigations — `captureScreenshot` returns stale frames |
| `raceStop` in capture loop | `recorder.ts` | `captureScreenshot` hangs during SPA nav, step executor finishes first, `stoppedPromise` kills the loop |
| CDP detach errors not handled | `recorder.ts` | "Not attached to an active page" errors count towards 10-error abort |

## Solution

### 1. New `spa` config option

```json
{
  "spa": true,
  "videos": {
    "my-spa-app": {
      "url": "/dashboard",
      "steps": [
        { "action": "click", "text": "Settings" },
        { "action": "wait", "text": "Account Settings" },
        { "action": "click", "text": "Back to Dashboard" },
        { "action": "pause", "ms": 2000 }
      ]
    }
  }
}
```

When `spa: true` (per-video or global):
- Uses standard **Chrome for Testing** with `--headless=new` (full rendering pipeline)
- The compositor correctly processes React/SPA DOM updates after client-side navigation

When `spa` is omitted or `false` (default):
- Uses `chrome-headless-shell` with `--enable-begin-frame-control` (existing behavior)
- Optimal for static page recordings with deterministic frame timing

### 2. Recorder resilience (unconditional — benefits all recordings)

**Timeout-based screenshot capture:** Replace `raceStop` with a 500ms `Promise.race` timeout for `captureScreenshot`. If a screenshot hangs during page transition, the loop retries instead of aborting. Only exits when `stop()` sets `running = false`.

**CDP error recovery:** Navigation-related CDP errors ("Not attached", "Target closed", "Session closed", "Execution context") trigger a 100ms retry instead of counting towards the 10-consecutive-error abort threshold.

## How to reproduce

1. Create any SPA app (Next.js, React Router, Inertia.js, etc.)
2. Write a WebReel config that clicks a link triggering client-side navigation
3. `webreel record` — video freezes at the first page

With this PR: add `"spa": true` to the config — full multi-page video.

## Changes

| File | Change |
|------|--------|
| `packages/@webreel/core/src/chrome.ts` | Add `spa` option to `LaunchChromeOptions`, use `ensureChrome()` + `--headless=new` when enabled |
| `packages/@webreel/core/src/recorder.ts` | Timeout-based screenshot capture + CDP error retry |
| `packages/webreel/src/lib/types.ts` | Add `spa` to `VideoConfig` and `WebreelConfig` |
| `packages/webreel/src/lib/config.ts` | Wire `spa` through config defaults/inheritance |
| `packages/webreel/src/lib/runner.ts` | Pass `spa` to `launchChrome` |