### PR TITLE
fix: prevent type action text from being used as element locator

### DIFF
--- a/packages/webreel/src/lib/runner.ts
+++ b/packages/webreel/src/lib/runner.ts
@@ -284,7 +284,7 @@ export async function runVideo(
 
           case "type": {
             if (step.selector) {
-              const box = await resolveTarget(client, step);
+              const box = await resolveTarget(client, { selector: step.selector, within: step.within });
               const { x: tx, y: ty } = randomPointInBox(box);
               await clickAt(ctx, client, tx, ty);
               await client.Runtime.evaluate({


### PR DESCRIPTION
## Summary

- Fixes a bug where the `type` action's `text` field (intended as content to type) is incorrectly passed to `resolveTarget`, which interprets it as an element locator
- When both `text` and `selector` are provided on a `type` step, `resolveTarget` checks `text` first and fails with `Element not found: text="<typed content>"`
- The fix passes only `{ selector, within }` to `resolveTarget`, keeping `text` reserved for the content to type

## Reproduction

```json
{
  "action": "type",
  "text": "user@example.com",
  "selector": "#email"
}
```

This fails with:
```
Element not found: text="user@example.com"
```

Because `resolveTarget` receives the full step object and prioritizes `opts.text` (line 81 of runner.ts) over `opts.selector`, treating the typed content as an element search query.

## Fix

```diff
- const box = await resolveTarget(client, step);
+ const box = await resolveTarget(client, { selector: step.selector, within: step.within });
```

## Test plan

- [ ] Verify `type` action with both `text` and `selector` correctly types into the targeted element
- [ ] Verify `type` action without `selector` still works (no change to that path)
- [ ] Verify existing `click`, `hover`, `moveTo` actions still resolve elements correctly (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)