### PR TITLE
feat(timeline): record step timing metadata

### DIFF
--- a/apps/docs/src/app/commands/page.mdx
+++ b/apps/docs/src/app/commands/page.mdx
@@ -138,7 +138,7 @@ webreel composite hero
 webreel composite -c custom.config.json
 ```
 
-Raw video and timeline data are stored in `.webreel/raw/` and `.webreel/timelines/` after the first recording.
+Raw video and timeline data are stored in `.webreel/raw/` and `.webreel/timelines/` after the first recording. Timeline JSON includes cursor frames, sound events, and per-step `startMs` / `endMs` metadata so recordings can be synced with chapters, logs, or other external traces.
 
 <table>
   <thead>

--- a/packages/@webreel/core/src/__tests__/timeline.test.ts
+++ b/packages/@webreel/core/src/__tests__/timeline.test.ts
@@ -6,6 +6,7 @@ describe("InteractionTimeline", () => {
     const tl = new InteractionTimeline(1080, 1080);
     expect(tl.getFrameCount()).toBe(0);
     expect(tl.getEvents()).toEqual([]);
+    expect(tl.getSteps()).toEqual([]);
   });
 
   it("tick advances frame count", () => {
@@ -33,6 +34,31 @@ describe("InteractionTimeline", () => {
     expect(events[0].timeMs).toBeCloseTo(1000, 0);
   });
 
+  it("tracks step timing metadata", () => {
+    const tl = new InteractionTimeline(1080, 1080);
+    const startMs = tl.getCurrentTimeMs();
+    for (let i = 0; i < 30; i++) tl.tick();
+    tl.addStep({
+      index: 0,
+      action: "pause",
+      startMs,
+      endMs: tl.getCurrentTimeMs(),
+      label: "intro",
+      description: "Let page render",
+    });
+
+    expect(tl.getSteps()).toEqual([
+      {
+        index: 0,
+        action: "pause",
+        startMs: 0,
+        endMs: 500,
+        label: "intro",
+        description: "Let page render",
+      },
+    ]);
+  });
+
   it("toJSON produces valid timeline data", () => {
     const tl = new InteractionTimeline(1920, 1080, { zoom: 2 });
     tl.tick();
@@ -42,6 +68,7 @@ describe("InteractionTimeline", () => {
     expect(data.height).toBe(1080);
     expect(data.zoom).toBe(2);
     expect(data.frames).toHaveLength(1);
+    expect(data.steps).toEqual([]);
     expect(data.theme.cursorSize).toBe(24);
   });
 
@@ -53,6 +80,7 @@ describe("InteractionTimeline", () => {
     tl.setCursorPath([{ x: 100, y: 200 }]);
     tl.tick();
     tl.addEvent("key");
+    tl.addStep({ index: 1, action: "key", startMs: 0, endMs: 16.666666666666668 });
     tl.tick();
 
     const json = tl.toJSON();
@@ -61,6 +89,7 @@ describe("InteractionTimeline", () => {
 
     expect(reJson.frames).toEqual(json.frames);
     expect(reJson.events).toEqual(json.events);
+    expect(reJson.steps).toEqual(json.steps);
     expect(reJson.width).toBe(json.width);
     expect(reJson.height).toBe(json.height);
     expect(reJson.zoom).toBe(json.zoom);

--- a/packages/@webreel/core/src/timeline.ts
+++ b/packages/@webreel/core/src/timeline.ts
@@ -44,6 +44,16 @@ export interface TimelineData {
   };
   frames: FrameData[];
   events: SoundEvent[];
+  steps: TimelineStep[];
+}
+
+export interface TimelineStep {
+  index: number;
+  action: string;
+  startMs: number;
+  endMs: number;
+  label?: string;
+  description?: string;
 }
 
 export class InteractionTimeline {
@@ -57,6 +67,7 @@ export class InteractionTimeline {
   private currentHud: HudState | null = null;
   private frames: FrameData[] = [];
   private events: SoundEvent[] = [];
+  private steps: TimelineStep[] = [];
   private frameCount = 0;
   private tickResolvers: Array<() => void> = [];
 
@@ -82,6 +93,7 @@ export class InteractionTimeline {
       hud?: Partial<TimelineData["theme"]["hud"]>;
       loadedFrames?: FrameData[];
       loadedEvents?: SoundEvent[];
+      loadedSteps?: TimelineStep[];
     },
   ) {
     this.width = width;
@@ -113,6 +125,9 @@ export class InteractionTimeline {
     if (options?.loadedEvents) {
       this.events = options.loadedEvents;
     }
+    if (options?.loadedSteps) {
+      this.steps = options.loadedSteps;
+    }
   }
 
   setCursorPath(positions: Point[]): void {
@@ -133,8 +148,16 @@ export class InteractionTimeline {
   }
 
   addEvent(type: "click" | "key"): void {
-    const timeMs = (this.frameCount / this.fps) * 1000;
+    const timeMs = this.getCurrentTimeMs();
     this.events.push({ type, timeMs });
+  }
+
+  addStep(step: TimelineStep): void {
+    this.steps.push(step);
+  }
+
+  getCurrentTimeMs(): number {
+    return (this.frameCount / this.fps) * 1000;
   }
 
   waitForNextTick(): Promise<void> {
@@ -176,6 +199,10 @@ export class InteractionTimeline {
     return this.events;
   }
 
+  getSteps(): TimelineStep[] {
+    return this.steps;
+  }
+
   getFrameCount(): number {
     return this.frameCount;
   }
@@ -194,6 +221,7 @@ export class InteractionTimeline {
       },
       frames: this.frames,
       events: this.events,
+      steps: this.steps,
     };
   }
 
@@ -211,6 +239,7 @@ export class InteractionTimeline {
       hud: json.theme.hud,
       loadedFrames: json.frames,
       loadedEvents: json.events,
+      loadedSteps: json.steps,
     });
   }
 }

--- a/packages/webreel/README.md
+++ b/packages/webreel/README.md
@@ -141,7 +141,7 @@ webreel composite
 webreel composite hero login
 ```
 
-Raw video and timeline data are saved in `.webreel/raw/` and `.webreel/timelines/` during `webreel record`. Use `composite` to re-apply cursor overlays, HUD, and sound effects without re-running the browser.
+Raw video and timeline data are saved in `.webreel/raw/` and `.webreel/timelines/` during `webreel record`. Timeline JSON includes cursor frames, sound events, and per-step `startMs` / `endMs` metadata so recordings can be synced with chapters, logs, or other external traces. Use `composite` to re-apply cursor overlays, HUD, and sound effects without re-running the browser.
 
 ## Config format
 

--- a/packages/webreel/src/lib/runner.ts
+++ b/packages/webreel/src/lib/runner.ts
@@ -247,6 +247,7 @@ export async function runVideo(
     for (let i = 0; i < config.steps.length; i++) {
       const step = config.steps[i];
       if (verbose) console.log(formatStep(i, step));
+      const stepStartMs = timeline?.getCurrentTimeMs();
 
       try {
         switch (step.action) {
@@ -405,6 +406,16 @@ export async function runVideo(
         const postDelay = stepDelay ?? config.defaultDelay;
         if (postDelay !== undefined && postDelay > 0) {
           await pause(postDelay);
+        }
+        if (timeline && stepStartMs !== undefined) {
+          timeline.addStep({
+            index: i,
+            action: step.action,
+            startMs: stepStartMs,
+            endMs: timeline.getCurrentTimeMs(),
+            ...(step.label ? { label: step.label } : {}),
+            ...(step.description ? { description: step.description } : {}),
+          });
         }
       } catch (err) {
         throw new Error(


### PR DESCRIPTION
## Summary

Adds per-step timing metadata to WebReel timeline JSON so recordings can be synchronized with chapters, logs, traces, or other post-processing artifacts.

Fixes #20.

## Changes

- Add steps metadata to TimelineData with index, action, startMs, endMs, and optional label / description
- Record each successful configured step from runVideo() using the timeline frame clock
- Preserve step metadata when loading saved timelines for re-composition
- Document that .webreel/timelines/*.timeline.json now includes step timing metadata
- Add core timeline regression coverage

## Verification

- pnpm install --frozen-lockfile
- pnpm --filter @webreel/core test -- src/__tests__/timeline.test.ts
- pnpm --filter @webreel/core type-check
- pnpm --filter @webreel/core build
- pnpm --filter webreel test -- src/lib/__tests__/runner.test.ts
- pnpm --filter webreel type-check
- pnpm lint
- pnpm format:check
- pnpm build
- git diff --check

Note: webreel package tests/typecheck need @webreel/core built first in this checkout because the workspace package exports dist.