### PR TITLE
Add navigateHref action for dynamic links

### DIFF
--- a/apps/docs/public/schema/v1.json
+++ b/apps/docs/public/schema/v1.json
@@ -340,6 +340,9 @@
           "$ref": "#/$defs/stepNavigate"
         },
         {
+          "$ref": "#/$defs/stepNavigateHref"
+        },
+        {
           "$ref": "#/$defs/stepHover"
         },
         {
@@ -696,6 +699,31 @@
           "type": "string",
           "minLength": 1,
           "description": "URL to navigate to. Resolved relative to baseUrl if set."
+        },
+        "label": {
+          "$ref": "#/$defs/label"
+        },
+        "delay": {
+          "$ref": "#/$defs/delay"
+        },
+        "description": {
+          "$ref": "#/$defs/description"
+        }
+      },
+      "additionalProperties": false
+    },
+    "stepNavigateHref": {
+      "type": "object",
+      "required": ["action", "selector"],
+      "properties": {
+        "action": {
+          "type": "string",
+          "const": "navigateHref"
+        },
+        "selector": {
+          "type": "string",
+          "minLength": 1,
+          "description": "CSS selector for an element with an href attribute."
         },
         "label": {
           "$ref": "#/$defs/label"

--- a/apps/docs/src/app/actions/page.mdx
+++ b/apps/docs/src/app/actions/page.mdx
@@ -440,6 +440,38 @@ Navigate to a new URL during a recording. Useful for multi-page flows where you 
   </tbody>
 </table>
 
+## navigateHref
+
+Read an element's `href` attribute and navigate the current page to that URL. This is useful when a workflow generates a fresh link during the recording, such as a preview, deployment, or published report URL.
+
+```json
+{ "action": "wait", "selector": "a.preview-link" }
+{ "action": "navigateHref", "selector": "a.preview-link" }
+```
+
+<table>
+  <thead>
+    <tr>
+      <th>Field</th>
+      <th>Type</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>
+        <code>selector</code>
+      </td>
+      <td>string</td>
+      <td>
+        CSS selector for an element with an <code>href</code> attribute
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+The href is resolved against the current page URL before navigation, so relative links work too.
+
 ## hover
 
 Hover over an element, triggering any CSS hover states or JavaScript hover handlers.

--- a/packages/webreel/src/lib/__tests__/config.test.ts
+++ b/packages/webreel/src/lib/__tests__/config.test.ts
@@ -194,6 +194,18 @@ describe("validateStep", () => {
     expect(errors).toEqual([]);
   });
 
+  it("validates navigateHref requires selector", () => {
+    const errors = validate({ action: "navigateHref" });
+    expect(errors).toContainEqual(
+      expect.objectContaining({ path: "videos.x.steps[0].selector" }),
+    );
+  });
+
+  it("accepts valid navigateHref", () => {
+    const errors = validate({ action: "navigateHref", selector: "a.preview-link" });
+    expect(errors).toEqual([]);
+  });
+
   it("accepts description field on any step", () => {
     const errors = validate({
       action: "pause",

--- a/packages/webreel/src/lib/__tests__/runner.test.ts
+++ b/packages/webreel/src/lib/__tests__/runner.test.ts
@@ -74,6 +74,11 @@ describe("formatStep", () => {
     expect(formatStep(0, step)).toBe('[step 0] navigate "https://example.com"');
   });
 
+  it("formats navigateHref step", () => {
+    const step: Step = { action: "navigateHref", selector: "a.preview-link" };
+    expect(formatStep(0, step)).toBe('[step 0] navigateHref selector="a.preview-link"');
+  });
+
   it("formats hover step", () => {
     const step: Step = { action: "hover", text: "Link" };
     expect(formatStep(0, step)).toBe('[step 0] hover text="Link"');

--- a/packages/webreel/src/lib/config.ts
+++ b/packages/webreel/src/lib/config.ts
@@ -288,6 +288,7 @@ const VALID_ACTIONS = new Set([
   "wait",
   "screenshot",
   "navigate",
+  "navigateHref",
   "hover",
   "select",
 ]);
@@ -379,6 +380,7 @@ const KNOWN_STEP_KEYS: Record<string, Set<string>> = {
   ]),
   screenshot: new Set(["action", "output", "label", "delay", "description"]),
   navigate: new Set(["action", "url", "label", "delay", "description"]),
+  navigateHref: new Set(["action", "selector", "label", "delay", "description"]),
   hover: new Set([
     "action",
     "text",
@@ -606,6 +608,15 @@ function validateStep(step: unknown, index: number): ValidationError[] {
     case "navigate":
       if (typeof s.url !== "string" || s.url.length === 0) {
         errors.push({ path: `${prefix}.url`, message: "Must be a non-empty string" });
+      }
+      break;
+
+    case "navigateHref":
+      if (typeof s.selector !== "string" || s.selector.length === 0) {
+        errors.push({
+          path: `${prefix}.selector`,
+          message: "Must be a non-empty CSS selector string",
+        });
       }
       break;
 

--- a/packages/webreel/src/lib/runner.ts
+++ b/packages/webreel/src/lib/runner.ts
@@ -54,6 +54,8 @@ export function formatStep(i: number, step: Step): string {
       return `[step ${i}] screenshot "${step.output}"${desc}`;
     case "navigate":
       return `[step ${i}] navigate "${step.url}"${desc}`;
+    case "navigateHref":
+      return `[step ${i}] navigateHref selector="${step.selector}"${desc}`;
     case "hover":
       return `[step ${i}] hover ${step.text ? `text="${step.text}"` : `selector="${step.selector}"`}${desc}`;
     case "select":
@@ -354,6 +356,25 @@ export async function runVideo(
           case "navigate": {
             const navUrl = resolveUrl(step.url, config.baseUrl ?? "", configDir);
             await navigate(client, navUrl);
+            break;
+          }
+
+          case "navigateHref": {
+            const result = await client.Runtime.evaluate({
+              expression: `(() => {
+                const el = document.querySelector(${JSON.stringify(step.selector)});
+                if (!el) throw new Error("Element not found: " + ${JSON.stringify(step.selector)});
+                const href = el.href || el.getAttribute("href");
+                if (!href) throw new Error("Element has no href: " + ${JSON.stringify(step.selector)});
+                return new URL(href, window.location.href).href;
+              })()`,
+              returnByValue: true,
+            });
+            const href = result.result?.value;
+            if (typeof href !== "string" || href.length === 0) {
+              throw new Error("navigateHref did not resolve a URL");
+            }
+            await navigate(client, href);
             break;
           }
 

--- a/packages/webreel/src/lib/types.ts
+++ b/packages/webreel/src/lib/types.ts
@@ -100,6 +100,14 @@ export interface StepNavigate {
   description?: string;
 }
 
+export interface StepNavigateHref {
+  action: "navigateHref";
+  selector: string;
+  label?: string;
+  delay?: number;
+  description?: string;
+}
+
 export interface StepHover {
   action: "hover";
   text?: string;
@@ -132,6 +140,7 @@ export type Step =
   | StepMoveTo
   | StepScreenshot
   | StepNavigate
+  | StepNavigateHref
   | StepHover
   | StepSelect;
 

--- a/skills/webreel/steps-reference.md
+++ b/skills/webreel/steps-reference.md
@@ -190,6 +190,20 @@ Navigate the browser to a new URL.
 { "action": "navigate", "url": "/settings" }
 ```
 
+## navigateHref
+
+Read an element's `href` attribute and navigate the browser to that URL. Use this for generated links that change each run, such as preview, deploy, or published report URLs.
+
+| Field      | Type             | Required | Description                                      |
+| ---------- | ---------------- | -------- | ------------------------------------------------ |
+| `action`   | `"navigateHref"` | yes      |                                                  |
+| `selector` | string           | yes      | CSS selector for an element with an `href` value |
+
+```json
+{ "action": "wait", "selector": "a.preview-link" }
+{ "action": "navigateHref", "selector": "a.preview-link" }
+```
+
 ## select
 
 Select a value in a `<select>` dropdown.


### PR DESCRIPTION
## Summary

Adds a `navigateHref` step action for following links whose URLs are generated during a recording.

This lets a script wait for a dynamic link, read its fresh `href` from the DOM, resolve it against the current page URL, and navigate the captured page to that destination.

Example:

```json
{ "action": "wait", "selector": "a.preview-link" }
{ "action": "navigateHref", "selector": "a.preview-link" }
```

## Why

Some product demos generate preview, deployment, report, or published-site links at runtime. A normal `click` can open a new tab or leave the recording attached to the original page, and hardcoding the URL is not possible when it changes every run.

`navigateHref` keeps these recordings deterministic without requiring the author to know the URL ahead of time.

## Changes

- Adds `StepNavigateHref` type.
- Adds validation for `navigateHref.selector`.
- Implements runtime navigation by reading `element.href || element.getAttribute("href")` and resolving it with `new URL(..., window.location.href)`.
- Adds dry-run/verbose formatting.
- Updates config tests and runner formatting tests.
- Updates docs, schema, and skill step reference.

## Verification

- `pnpm --filter @webreel/core build`
- `pnpm --filter webreel test`
- `pnpm type-check`
- `pnpm build`
- `pnpm test`
- `pnpm lint`
- `pnpm format:check`

I also verified the built CLI with a local fixture where `navigateHref` follows a relative link from `index.html` to `target.html`, waits for the target page text, and captures a screenshot successfully.
