### PR TITLE
fix: keep synthetic pointer coordinates in CSS pixels while recording

### DIFF
--- a/packages/@webreel/core/src/__tests__/drag.test.ts
+++ b/packages/@webreel/core/src/__tests__/drag.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from "vitest";
+import { stripGhostIdentity } from "../actions.js";
+
+describe("stripGhostIdentity", () => {
+  function fakeElement(
+    attrs: Record<string, string>,
+    children: Record<string, string>[] = [],
+  ) {
+    const make = (a: Record<string, string>) => ({
+      attrs: { ...a },
+      get attributes() {
+        return Object.keys(this.attrs).map((name) => ({ name }));
+      },
+      removeAttribute(name: string) {
+        delete this.attrs[name];
+      },
+      querySelectorAll: () => [] as never[],
+    });
+    const root = make(attrs);
+    const kids = children.map(make);
+    root.querySelectorAll = () => kids as never;
+    return { root, kids };
+  }
+
+  it("removes the attributes a later selector lookup could match", () => {
+    const { root } = fakeElement({
+      id: "weight",
+      name: "weight",
+      "data-testid": "slider-weight",
+      "data-state": "active",
+      role: "slider",
+      class: "thumb",
+    });
+    stripGhostIdentity(root);
+    expect(root.attrs).toEqual({ role: "slider", class: "thumb" });
+  });
+
+  it("strips descendants too", () => {
+    const { root, kids } = fakeElement({ id: "row" }, [
+      { id: "input", "data-testid": "value" },
+    ]);
+    stripGhostIdentity(root);
+    expect(root.attrs).toEqual({});
+    expect(kids[0].attrs).toEqual({});
+  });
+});

--- a/packages/@webreel/core/src/__tests__/recorder.test.ts
+++ b/packages/@webreel/core/src/__tests__/recorder.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from "vitest";
+import { Recorder } from "../recorder.js";
+
+describe("Recorder capture parameters", () => {
+  it("captures at the emulated size when there is no zoom", () => {
+    const recorder = new Recorder(1920, 1024, {
+      capture: { width: 1920, height: 1024, scale: 1 },
+    });
+    expect(recorder.getCaptureParams().clip).toBeUndefined();
+  });
+
+  it("applies the zoom with clip.scale rather than a device scale factor", () => {
+    const recorder = new Recorder(1920, 1024, {
+      capture: { width: 3008, height: 1604, scale: 0.638 },
+    });
+    expect(recorder.getCaptureParams().clip).toEqual({
+      x: 0,
+      y: 0,
+      width: 3008,
+      height: 1604,
+      scale: 0.638,
+    });
+  });
+});

--- a/packages/@webreel/core/src/actions.ts
+++ b/packages/@webreel/core/src/actions.ts
@@ -675,6 +675,29 @@ export async function typeText(
   }
 }
 
+/**
+ * Strips the attributes that make a cloned drag ghost answer to the same
+ * selectors as the element it was cloned from. Serialised into the page, so it
+ * has to stay self-contained.
+ */
+export function stripGhostIdentity(root: {
+  removeAttribute(name: string): void;
+  attributes: ArrayLike<{ name: string }>;
+  querySelectorAll(selector: string): ArrayLike<{
+    removeAttribute(name: string): void;
+    attributes: ArrayLike<{ name: string }>;
+  }>;
+}): void {
+  const nodes = [root, ...Array.from(root.querySelectorAll("*"))];
+  for (const node of nodes) {
+    node.removeAttribute("id");
+    node.removeAttribute("name");
+    for (const attr of Array.from(node.attributes)) {
+      if (attr.name.startsWith("data-")) node.removeAttribute(attr.name);
+    }
+  }
+}
+
 export async function dragFromTo(
   ctx: RecordingContext,
   client: CDPClient,
@@ -701,7 +724,12 @@ export async function dragFromTo(
       const src = el?.closest("[draggable]") || el;
       if (src) {
         const ghost = src.cloneNode(true);
+        // The clone carries every attribute the source had, so until these are
+        // stripped it answers to the same selectors as the element being
+        // dragged and can shadow it in a later step's lookup.
+        (${stripGhostIdentity.toString()})(ghost);
         ghost.id = "__demo-drag-ghost";
+        ghost.setAttribute("aria-hidden", "true");
         const rect = src.getBoundingClientRect();
         ghost.style.cssText = [
           "position:fixed",
@@ -837,8 +865,16 @@ export async function dragFromTo(
 export async function captureScreenshot(
   client: CDPClient,
   outputPath: string,
+  area?: { width: number; height: number; scale: number },
 ): Promise<void> {
-  const { data } = await client.Page.captureScreenshot({ format: "png" });
+  const { data } = await client.Page.captureScreenshot({
+    format: "png",
+    ...(area && area.scale !== 1
+      ? {
+          clip: { x: 0, y: 0, width: area.width, height: area.height, scale: area.scale },
+        }
+      : {}),
+  });
   mkdirSync(dirname(outputPath), { recursive: true });
   writeFileSync(outputPath, Buffer.from(data, "base64"));
 }

--- a/packages/@webreel/core/src/index.ts
+++ b/packages/@webreel/core/src/index.ts
@@ -34,9 +34,10 @@ export {
   pressKey,
   typeText,
   dragFromTo,
+  stripGhostIdentity,
   captureScreenshot,
 } from "./actions.js";
-export { Recorder } from "./recorder.js";
+export { Recorder, type CaptureArea } from "./recorder.js";
 export { InteractionTimeline, type TimelineData } from "./timeline.js";
 export { compose, type ComposeOptions } from "./compositor.js";
 export { ensureFfmpeg, FFMPEG_CACHE_DIR } from "./ffmpeg.js";

--- a/packages/@webreel/core/src/recorder.ts
+++ b/packages/@webreel/core/src/recorder.ts
@@ -9,6 +9,18 @@ import { ensureFfmpeg } from "./ffmpeg.js";
 import { finalizeMp4, finalizeWebm, finalizeGif, type SfxConfig } from "./media.js";
 import type { InteractionTimeline, TimelineData } from "./timeline.js";
 
+/** Region of the page to capture, in CSS pixels, and the scale to capture it at. */
+export interface CaptureArea {
+  width: number;
+  height: number;
+  scale: number;
+}
+
+interface CaptureClip extends CaptureArea {
+  x: number;
+  y: number;
+}
+
 export class Recorder {
   private outputPath = "";
   private frameCount = 0;
@@ -31,11 +43,18 @@ export class Recorder {
   private framesDir: string | null = null;
   private stopResolve: (() => void) | null = null;
   private stoppedPromise: Promise<void> | null = null;
+  private captureClip: CaptureClip | null = null;
 
   constructor(
     outputWidth = DEFAULT_VIEWPORT_SIZE,
     outputHeight = DEFAULT_VIEWPORT_SIZE,
-    options?: { sfx?: SfxConfig; fps?: number; crf?: number; framesDir?: string },
+    options?: {
+      sfx?: SfxConfig;
+      fps?: number;
+      crf?: number;
+      framesDir?: string;
+      capture?: CaptureArea;
+    },
   ) {
     this.outputWidth = outputWidth;
     this.outputHeight = outputHeight;
@@ -43,10 +62,33 @@ export class Recorder {
     this.fps = options?.fps ?? TARGET_FPS;
     this.frameMs = 1000 / this.fps;
     this.crf = options?.crf ?? 18;
+    if (options?.capture && options.capture.scale !== 1) {
+      this.captureClip = {
+        x: 0,
+        y: 0,
+        width: options.capture.width,
+        height: options.capture.height,
+        scale: options.capture.scale,
+      };
+    }
     if (options?.framesDir) {
       this.framesDir = options.framesDir;
       mkdirSync(this.framesDir, { recursive: true });
     }
+  }
+
+  /**
+   * Parameters for one frame capture. The zoom is applied here, via clip.scale,
+   * rather than by emulating a device scale factor, which corrupts input
+   * coordinates while the capture loop runs.
+   */
+  getCaptureParams(): Record<string, unknown> {
+    return {
+      format: "jpeg",
+      quality: 60,
+      optimizeForSpeed: true,
+      ...(this.captureClip ? { clip: this.captureClip } : {}),
+    };
   }
 
   setTimeline(timeline: InteractionTimeline): void {
@@ -164,9 +206,9 @@ export class Recorder {
 
     while (this.running) {
       try {
-        if (this.timeline) {
-          this.timeline.tick();
-        } else {
+        // A page-drawn cursor has to move before the pixels are taken; the
+        // composited overlay is advanced after the capture instead (see below).
+        if (!this.timeline) {
           const evalResult = await this.raceStop(
             client.Runtime.evaluate({
               expression: "window.__tickCursor&&window.__tickCursor()",
@@ -174,12 +216,9 @@ export class Recorder {
           );
           if (!evalResult) break;
         }
+
         const screenshotResult = await this.raceStop(
-          client.Page.captureScreenshot({
-            format: "jpeg",
-            quality: 60,
-            optimizeForSpeed: true,
-          }),
+          client.Page.captureScreenshot(this.getCaptureParams()),
         );
         if (!screenshotResult) break;
 
@@ -188,6 +227,9 @@ export class Recorder {
         const elapsed = now - lastFrameTime;
         const frameSlots = Math.min(3, Math.max(1, Math.round(elapsed / this.frameMs)));
 
+        // Duplicates stand in for time that has already passed, so they keep
+        // the previous cursor state; only the frame these pixels belong to
+        // advances it.
         if (frameSlots > 1) {
           for (let i = 0; i < frameSlots - 1; i++) {
             if (this.timeline) this.timeline.tickDuplicate();
@@ -195,6 +237,13 @@ export class Recorder {
             this.frameCount++;
           }
         }
+
+        // captureScreenshot resolves with pixels sampled at the moment it
+        // returns rather than when it was called, so the overlay cursor is
+        // advanced here. Advancing before the capture dates the cursor in every
+        // frame one round trip (tens of milliseconds) behind the UI drawn in
+        // the same frame, which reads as the cursor lagging during drags.
+        if (this.timeline) this.timeline.tick();
 
         await this.writeFrame(buffer);
         this.frameCount++;

--- a/packages/webreel/src/lib/runner.ts
+++ b/packages/webreel/src/lib/runner.ts
@@ -73,6 +73,7 @@ export function resolveKeyTarget(target: string | ElementTarget): string {
 async function resolveTarget(
   client: CDPClient,
   opts: { text?: string; selector?: string; within?: string },
+  role?: string,
 ): Promise<BoundingBox> {
   if (!opts.text && !opts.selector) {
     throw new Error(`resolveTarget requires "text" or "selector"`);
@@ -86,7 +87,8 @@ async function resolveTarget(
   if (!box) {
     const target = opts.text ? `text="${opts.text}"` : `selector="${opts.selector}"`;
     const scope = opts.within ? ` within "${opts.within}"` : "";
-    throw new Error(`Element not found: ${target}${scope}`);
+    const which = role ? ` (${role})` : "";
+    throw new Error(`Element not found${which}: ${target}${scope}`);
   }
   return box;
 }
@@ -159,10 +161,15 @@ export async function runVideo(
     clientRef = client;
     await client.Page.enable();
     await client.Runtime.enable();
+    // The device scale factor stays at 1 and the zoom is applied when each
+    // frame is captured instead. Emulating a non-1 scale factor makes Chrome
+    // treat Input.dispatchMouseEvent coordinates as device pixels for as long
+    // as the capture loop is running, so every synthetic pointer event lands at
+    // coordinates/zoom.
     await client.Emulation.setDeviceMetricsOverride({
       width: cssWidth,
       height: cssHeight,
-      deviceScaleFactor: zoom,
+      deviceScaleFactor: 1,
       mobile: false,
     });
 
@@ -233,6 +240,7 @@ export async function runVideo(
         crf,
         framesDir,
         sfx: config.sfx,
+        capture: { width: cssWidth, height: cssHeight, scale: zoom },
       });
       recorder.setTimeline(timeline);
       await recorder.start(client, outputPath, ctx);
@@ -276,8 +284,8 @@ export async function runVideo(
           }
 
           case "drag": {
-            const fromBox = await resolveTarget(client, step.from);
-            const toBox = await resolveTarget(client, step.to);
+            const fromBox = await resolveTarget(client, step.from, "drag from");
+            const toBox = await resolveTarget(client, step.to, "drag to");
             await dragFromTo(ctx, client, fromBox, toBox);
             break;
           }
@@ -340,7 +348,11 @@ export async function runVideo(
           }
 
           case "screenshot": {
-            await captureScreenshot(client, resolve(configDir, step.output));
+            await captureScreenshot(client, resolve(configDir, step.output), {
+              width: cssWidth,
+              height: cssHeight,
+              scale: zoom,
+            });
             break;
           }
 


### PR DESCRIPTION
## Summary

`drag` steps silently do nothing whenever `zoom` is set to anything other than 1, and every recorded frame pairs the UI with a cursor position from slightly earlier. Both come from the recording pipeline rather than the drag code itself.

### Pointer coordinates are device-scaled during recording

`runVideo` emulates `deviceScaleFactor: zoom` so `Page.captureScreenshot` returns frames at the output size. While the capture loop is running, that also makes Chrome interpret `Input.dispatchMouseEvent` coordinates as device pixels. Measured with a page that logs what it receives, at `zoom: 0.638`:

| state | sent | page received |
| --- | --- | --- |
| before the capture loop starts | 1000,500 | 1000,500 |
| capture loop running | 1000,500 | 1566,783 |
| capture loop running | 638,319 (= x zoom) | 1000,500 |
| after the loop stops | 1000,500 | 1000,500 |

Clicks and typing are unaffected, because `clickAt` blocks the CDP-generated events and re-dispatches the chain from page JS (the comment there already calls CDP input unreliable). `dragFromTo` also fires `dragstart`/`dragover`/`drop` from JS at correct CSS coordinates, which is why `examples/drag-and-drop` still works despite running at `zoom: 2`: HTML5 drag and drop never needs the real pointer. Anything driven by actual pointer events, such as a Radix slider that takes pointer capture on the thumb, gets the raw CDP coordinates, so a press aimed at a slider thumb at (2936, 395) arrived at (4600, 620): outside the popover being dragged in, which dismissed it, left the drag doing nothing, and made the following step fail to resolve its target.

The fix applies the zoom with `clip.scale` at capture time and leaves the emulated scale factor at 1. Frames come out at the same size, capture is marginally faster in a 10-frame benchmark (422ms vs 461ms), and coordinates stay 1:1 for the whole recording. `screenshot` steps pass the same scale so their output size does not change.

### The cursor overlay trails the frame it is drawn on

The capture loop advanced the cursor before capturing, but `captureScreenshot` resolves with pixels sampled at the moment it returns, not when it was called. Timing it against a marker moving at a known speed: pixels are dated 45ms after the call starts and within 2ms of when it returns (mean round trip 47ms).

So each frame paired UI from time T with a cursor position from T minus one round trip. Measured on a page whose dot follows the real pointer exactly, at 1920x1024:

| | mean gap between pointer and drawn cursor |
| --- | --- |
| before | 50.7px at 56px/frame, about 30ms |
| after | 0.9px, about 1ms |

The overlay now advances after the capture. Duplicate frames keep the previous cursor state, since they stand in for time that has already passed.

### Two smaller drag fixes

- Drag ghosts are deep clones and kept the `id`, `name` and `data-*` attributes of their source, so for the 200ms before the ghost is removed a selector could match the ghost instead of the real element. This is how the failure above surfaced: the next step resolved `[data-testid="slider-weight"]` against the leftover ghost and then failed on the other endpoint, which pointed away from the actual cause.
- A drag that cannot resolve an endpoint now says which end it was.

## Test plan

- [x] `pnpm test` (105 core, 109 webreel), `pnpm type-check`, `pnpm lint`, `pnpm format:check`
- [x] New unit tests for the capture parameters and the ghost attribute stripping
- [x] Recorded a 25-step config at `zoom: 0.638` that previously failed at the first drag: all steps complete and the five slider drags land on the values they should
- [x] Re-recorded `examples/drag-and-drop` (`zoom: 2`) with both builds and compared the final frames: identical

No changeset here, per the release process in AGENTS.md; happy to send one in a follow-up PR.

Found while recording a variable-font explorer with sliders. Generated with [Claude Code](https://claude.com/claude-code)
