### PR TITLE
feat: add cursorSpeed to control how fast the cursor travels

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@ All steps (except `pause`) accept an optional `delay` field (ms to wait after th
 | `theme`        | -         | Default cursor and HUD overlay customization |
 | `include`      | -         | Array of step files prepended to all videos  |
 | `defaultDelay` | -         | Default delay (ms) after each step           |
+| `cursorSpeed`  | `1`       | Multiplier on how fast the cursor travels    |
 | `videos`       | required  | Object mapping video names to their configs  |
 
 #### Per-video
@@ -211,6 +212,7 @@ All steps (except `pause`) accept an optional `delay` field (ms to wait after th
 | `include`      | inherited     | Array of paths to JSON files whose steps are prepended |
 | `theme`        | inherited     | Cursor and HUD overlay customization                   |
 | `defaultDelay` | inherited     | Default delay (ms) after each step                     |
+| `cursorSpeed`  | inherited     | Multiplier on how fast the cursor travels              |
 
 ## Development
 

--- a/apps/docs/public/schema/v1.json
+++ b/apps/docs/public/schema/v1.json
@@ -48,6 +48,11 @@
       "minimum": 0,
       "description": "Milliseconds the cursor pauses after reaching its target before clicking. Simulates human dwell time. Defaults to a random 80-180ms when not set. Set to 0 to click instantly."
     },
+    "cursorSpeed": {
+      "type": "number",
+      "exclusiveMinimum": 0,
+      "description": "Multiplier on how fast the cursor travels between targets. 1 is the default pace, 2 covers the same ground in half the time. Does not affect typing speed, click dwell or step delays."
+    },
     "videos": {
       "type": "object",
       "minProperties": 1,
@@ -296,6 +301,11 @@
           "type": "number",
           "minimum": 0,
           "description": "Milliseconds the cursor pauses after reaching its target before clicking. Overrides the top-level clickDwell."
+        },
+        "cursorSpeed": {
+          "type": "number",
+          "exclusiveMinimum": 0,
+          "description": "Multiplier on how fast the cursor travels between targets. Overrides the top-level cursorSpeed."
         },
         "steps": {
           "type": "array",

--- a/apps/docs/src/app/configuration/page.mdx
+++ b/apps/docs/src/app/configuration/page.mdx
@@ -126,6 +126,16 @@ These fields apply as defaults to all videos and can be overridden per-video.
     </tr>
     <tr>
       <td>
+        <code>cursorSpeed</code>
+      </td>
+      <td>1</td>
+      <td>
+        Multiplier on how fast the cursor travels between targets. <code>2</code> covers
+        the same ground in half the time.
+      </td>
+    </tr>
+    <tr>
+      <td>
         <code>sfx</code>
       </td>
       <td>-</td>
@@ -259,6 +269,13 @@ Each key in the `videos` object is the video name (used as the default output fi
     </tr>
     <tr>
       <td>
+        <code>cursorSpeed</code>
+      </td>
+      <td>inherited</td>
+      <td>Multiplier on how fast the cursor travels</td>
+    </tr>
+    <tr>
+      <td>
         <code>sfx</code>
       </td>
       <td>inherited</td>
@@ -305,6 +322,25 @@ When the cursor reaches its target, it pauses briefly before clicking, just like
     "hero": {
       "url": "/",
       "clickDwell": 0,
+      "steps": [{ "action": "click", "text": "Get Started" }]
+    }
+  }
+}
+```
+
+## cursorSpeed
+
+Cursor travel is timed from the distance it covers, so long moves take longer than
+short ones. `cursorSpeed` scales that: `2` covers the same ground in half the time,
+`0.5` takes twice as long. Typing speed, click dwell and step delays are unaffected.
+
+```json
+{
+  "cursorSpeed": 1.75,
+  "videos": {
+    "hero": {
+      "url": "/",
+      "cursorSpeed": 1,
       "steps": [{ "action": "click", "text": "Get Started" }]
     }
   }

--- a/packages/@webreel/core/src/__tests__/cursor-motion.test.ts
+++ b/packages/@webreel/core/src/__tests__/cursor-motion.test.ts
@@ -43,3 +43,27 @@ describe("computeDragTiming", () => {
     expect(delayMs).toBeGreaterThan(0);
   });
 });
+
+describe("computeDragTiming speed", () => {
+  it("takes about half as long at twice the speed", () => {
+    // The jitter term is +/-20ms, so compare totals over several samples.
+    const total = (speed: number) => {
+      let sum = 0;
+      for (let i = 0; i < 40; i++) {
+        const { steps, delayMs } = computeDragTiming(900, speed);
+        sum += steps * delayMs;
+      }
+      return sum / 40;
+    };
+    const normal = total(1);
+    const fast = total(2);
+    expect(fast).toBeGreaterThan(normal / 2 - 30);
+    expect(fast).toBeLessThan(normal / 2 + 30);
+  });
+
+  it("defaults to unchanged timing", () => {
+    const a = computeDragTiming(400);
+    const b = computeDragTiming(400, 1);
+    expect(Math.abs(a.steps * a.delayMs - b.steps * b.delayMs)).toBeLessThan(60);
+  });
+});

--- a/packages/@webreel/core/src/__tests__/recording-context.test.ts
+++ b/packages/@webreel/core/src/__tests__/recording-context.test.ts
@@ -50,3 +50,26 @@ describe("RecordingContext", () => {
     expect(events).toEqual(["click"]);
   });
 });
+
+describe("RecordingContext cursor speed", () => {
+  it("defaults to 1", () => {
+    expect(new RecordingContext().cursorSpeed).toBe(1);
+  });
+
+  it("takes a positive multiplier", () => {
+    const ctx = new RecordingContext();
+    ctx.setCursorSpeed(2.5);
+    expect(ctx.cursorSpeed).toBe(2.5);
+  });
+
+  it("falls back to 1 for undefined or nonsense values", () => {
+    const ctx = new RecordingContext();
+    ctx.setCursorSpeed(2);
+    ctx.setCursorSpeed(undefined);
+    expect(ctx.cursorSpeed).toBe(1);
+    ctx.setCursorSpeed(0);
+    expect(ctx.cursorSpeed).toBe(1);
+    ctx.setCursorSpeed(-3);
+    expect(ctx.cursorSpeed).toBe(1);
+  });
+});

--- a/packages/@webreel/core/src/actions.ts
+++ b/packages/@webreel/core/src/actions.ts
@@ -19,6 +19,7 @@ export class RecordingContext {
   private _cursorX = -OFFSCREEN_MARGIN;
   private _cursorY = -OFFSCREEN_MARGIN;
   private _clickDwell: number | undefined;
+  private _cursorSpeed = 1;
 
   get mode(): "record" | "preview" {
     return this._mode;
@@ -84,6 +85,15 @@ export class RecordingContext {
 
   setClickDwell(ms: number | undefined): void {
     this._clickDwell = ms;
+  }
+
+  /** Multiplier on how fast the cursor travels. 2 covers ground twice as fast. */
+  setCursorSpeed(speed: number | undefined): void {
+    this._cursorSpeed = speed && speed > 0 ? speed : 1;
+  }
+
+  get cursorSpeed(): number {
+    return this._cursorSpeed;
   }
 
   getClickDwellMs(): number {
@@ -742,7 +752,7 @@ export async function dragFromTo(
   await pause(150);
 
   const dist = Math.sqrt((tx - fx) * (tx - fx) + (ty - fy) * (ty - fy));
-  const { steps, delayMs } = computeDragTiming(dist);
+  const { steps, delayMs } = computeDragTiming(dist, ctx.cursorSpeed);
   const waypoints = computeEasedPath(fx, fy, tx, ty, steps);
 
   for (const wp of waypoints) {

--- a/packages/@webreel/core/src/cursor-motion.ts
+++ b/packages/@webreel/core/src/cursor-motion.ts
@@ -8,8 +8,8 @@ import type { RecordingContext } from "./actions.js";
  * instant, and long cross-screen moves have enough frames to
  * appear smooth at the target capture rate.
  */
-function moveDuration(distance: number): number {
-  return 180 + 16 * Math.sqrt(distance) + (Math.random() - 0.5) * 30;
+function moveDuration(distance: number, speed = 1): number {
+  return (180 + 16 * Math.sqrt(distance) + (Math.random() - 0.5) * 30) / speed;
 }
 
 /**
@@ -76,7 +76,7 @@ export async function animateMoveTo(
 
   if (dist < 1) return;
 
-  const duration = moveDuration(dist);
+  const duration = moveDuration(dist, ctx.cursorSpeed);
   const ctrl = bezierControl(fromX, fromY, toX, toY, dist);
   const p0: Point = { x: fromX, y: fromY };
   const p2: Point = { x: toX, y: toY };
@@ -173,11 +173,14 @@ export function computeEasedPath(
   return pts;
 }
 
-export function computeDragTiming(distance: number): {
+export function computeDragTiming(
+  distance: number,
+  speed = 1,
+): {
   steps: number;
   delayMs: number;
 } {
-  const duration = 300 + 20 * Math.sqrt(distance) + (Math.random() - 0.5) * 40;
+  const duration = (300 + 20 * Math.sqrt(distance) + (Math.random() - 0.5) * 40) / speed;
   const steps = Math.max(12, Math.round(duration / 30));
   return { steps, delayMs: duration / steps };
 }

--- a/packages/webreel/src/config.ts
+++ b/packages/webreel/src/config.ts
@@ -33,6 +33,7 @@ export interface InputWebreelConfig {
   include?: string[];
   defaultDelay?: number;
   clickDwell?: number;
+  cursorSpeed?: number;
   videos: Record<string, InputVideoConfig>;
 }
 

--- a/packages/webreel/src/lib/__tests__/config.test.ts
+++ b/packages/webreel/src/lib/__tests__/config.test.ts
@@ -30,6 +30,28 @@ describe("validateWebreelConfig videos", () => {
     expect(errors).toContainEqual(expect.objectContaining({ path: "videos.x.steps" }));
   });
 
+  it("rejects a non-positive cursorSpeed", () => {
+    const errors = validateWebreelConfig({ cursorSpeed: 0, videos: {} });
+    expect(errors).toContainEqual(expect.objectContaining({ path: "cursorSpeed" }));
+  });
+
+  it("accepts a positive cursorSpeed at the top level and per video", () => {
+    const errors = validateWebreelConfig({
+      cursorSpeed: 2,
+      videos: { x: { url: "u", cursorSpeed: 1.5, steps: [] } },
+    });
+    expect(errors).toEqual([]);
+  });
+
+  it("rejects a non-positive cursorSpeed on a video", () => {
+    const errors = validateWebreelConfig(
+      wrapVideo({ url: "u", cursorSpeed: -1, steps: [] }),
+    );
+    expect(errors).toContainEqual(
+      expect.objectContaining({ path: "videos.x.cursorSpeed" }),
+    );
+  });
+
   it("validates video viewport dimensions", () => {
     const errors = validateWebreelConfig(
       wrapVideo({

--- a/packages/webreel/src/lib/__tests__/schema.test.ts
+++ b/packages/webreel/src/lib/__tests__/schema.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { KNOWN_TOP_LEVEL_KEYS, KNOWN_VIDEO_KEYS, KNOWN_STEP_KEYS } from "../config.js";
+
+// The published schema sets additionalProperties: false, so any option the
+// validator accepts but the schema omits is reported as an error by editors.
+const schema = JSON.parse(
+  readFileSync(
+    resolve(import.meta.dirname, "../../../../../apps/docs/public/schema/v1.json"),
+    "utf-8",
+  ),
+) as {
+  properties: Record<string, unknown>;
+  $defs: Record<string, { properties?: Record<string, unknown> }>;
+};
+
+describe("published JSON schema", () => {
+  it("documents every top-level option the validator accepts", () => {
+    const missing = [...KNOWN_TOP_LEVEL_KEYS].filter(
+      (key) => !(key in schema.properties),
+    );
+    expect(missing).toEqual([]);
+  });
+
+  it("documents every per-video option the validator accepts", () => {
+    const props = schema.$defs.video.properties ?? {};
+    const missing = [...KNOWN_VIDEO_KEYS].filter((key) => !(key in props));
+    expect(missing).toEqual([]);
+  });
+
+  it("documents every step field the validator accepts", () => {
+    const missing: string[] = [];
+    for (const [action, keys] of Object.entries(KNOWN_STEP_KEYS)) {
+      const def = schema.$defs[`step${action[0].toUpperCase()}${action.slice(1)}`];
+      expect(
+        def,
+        `schema is missing a definition for the "${action}" step`,
+      ).toBeDefined();
+      const props = def.properties ?? {};
+      for (const key of keys) if (!(key in props)) missing.push(`${action}.${key}`);
+    }
+    expect(missing).toEqual([]);
+  });
+});

--- a/packages/webreel/src/lib/config.ts
+++ b/packages/webreel/src/lib/config.ts
@@ -92,7 +92,14 @@ function resolveVideoDefaults(
   defaults: Partial<
     Pick<
       WebreelConfig,
-      "baseUrl" | "viewport" | "theme" | "include" | "defaultDelay" | "clickDwell" | "sfx"
+      | "baseUrl"
+      | "viewport"
+      | "theme"
+      | "include"
+      | "defaultDelay"
+      | "clickDwell"
+      | "cursorSpeed"
+      | "sfx"
     >
   >,
   outDir: string | undefined,
@@ -114,6 +121,8 @@ function resolveVideoDefaults(
     resolved.defaultDelay = defaults.defaultDelay;
   if (resolved.clickDwell === undefined && defaults.clickDwell !== undefined)
     resolved.clickDwell = defaults.clickDwell;
+  if (resolved.cursorSpeed === undefined && defaults.cursorSpeed !== undefined)
+    resolved.cursorSpeed = defaults.cursorSpeed;
   if (resolved.output && !isAbsolute(resolved.output) && outDir) {
     resolved.output = resolve(outDir, resolved.output);
   } else if (!resolved.output && outDir) {
@@ -177,6 +186,7 @@ async function buildConfigFromParsed(
     include: parsed.include as string[] | undefined,
     defaultDelay: parsed.defaultDelay as number | undefined,
     clickDwell: parsed.clickDwell as number | undefined,
+    cursorSpeed: parsed.cursorSpeed as number | undefined,
   };
 
   const videoList: VideoConfig[] = [];
@@ -201,6 +211,7 @@ async function buildConfigFromParsed(
     include: parsed.include as string[] | undefined,
     defaultDelay: parsed.defaultDelay as number | undefined,
     clickDwell: parsed.clickDwell as number | undefined,
+    cursorSpeed: parsed.cursorSpeed as number | undefined,
     videos: videoList,
   };
 }
@@ -302,6 +313,7 @@ const KNOWN_TOP_LEVEL_KEYS = new Set([
   "include",
   "defaultDelay",
   "clickDwell",
+  "cursorSpeed",
   "videos",
 ]);
 
@@ -320,6 +332,7 @@ const KNOWN_VIDEO_KEYS = new Set([
   "sfx",
   "defaultDelay",
   "clickDwell",
+  "cursorSpeed",
   "steps",
 ]);
 
@@ -853,6 +866,13 @@ export function validateWebreelConfig(
     errors.push({ path: "clickDwell", message: "Must be a non-negative number" });
   }
 
+  if (
+    c.cursorSpeed !== undefined &&
+    (!Number.isFinite(c.cursorSpeed) || (c.cursorSpeed as number) <= 0)
+  ) {
+    errors.push({ path: "cursorSpeed", message: "Must be a positive number" });
+  }
+
   if (c.include !== undefined) {
     errors.push(...validateInclude(c.include, "include"));
   }
@@ -987,6 +1007,16 @@ export function validateWebreelConfig(
       errors.push({
         path: `${prefix}.clickDwell`,
         message: "Must be a non-negative number",
+      });
+    }
+
+    if (
+      d.cursorSpeed !== undefined &&
+      (!Number.isFinite(d.cursorSpeed) || (d.cursorSpeed as number) <= 0)
+    ) {
+      errors.push({
+        path: `${prefix}.cursorSpeed`,
+        message: "Must be a positive number",
       });
     }
 

--- a/packages/webreel/src/lib/config.ts
+++ b/packages/webreel/src/lib/config.ts
@@ -303,7 +303,7 @@ const VALID_ACTIONS = new Set([
   "select",
 ]);
 
-const KNOWN_TOP_LEVEL_KEYS = new Set([
+export const KNOWN_TOP_LEVEL_KEYS = new Set([
   "$schema",
   "outDir",
   "baseUrl",
@@ -317,7 +317,7 @@ const KNOWN_TOP_LEVEL_KEYS = new Set([
   "videos",
 ]);
 
-const KNOWN_VIDEO_KEYS = new Set([
+export const KNOWN_VIDEO_KEYS = new Set([
   "url",
   "baseUrl",
   "viewport",
@@ -336,7 +336,7 @@ const KNOWN_VIDEO_KEYS = new Set([
   "steps",
 ]);
 
-const KNOWN_STEP_KEYS: Record<string, Set<string>> = {
+export const KNOWN_STEP_KEYS: Record<string, Set<string>> = {
   pause: new Set(["action", "ms", "label", "description"]),
   click: new Set([
     "action",

--- a/packages/webreel/src/lib/runner.ts
+++ b/packages/webreel/src/lib/runner.ts
@@ -148,6 +148,7 @@ export async function runVideo(
   const ctx = new RecordingContext();
   ctx.resetCursorPosition(cssWidth, cssHeight);
   if (config.clickDwell !== undefined) ctx.setClickDwell(config.clickDwell);
+  if (config.cursorSpeed !== undefined) ctx.setCursorSpeed(config.cursorSpeed);
   const initialCursor = ctx.getCursorPosition();
 
   const chrome = await launchChrome({ headless: shouldRecord });

--- a/packages/webreel/src/lib/types.ts
+++ b/packages/webreel/src/lib/types.ts
@@ -188,6 +188,12 @@ export interface VideoConfig {
   sfx?: SfxConfig;
   defaultDelay?: number;
   clickDwell?: number;
+  /**
+   * Multiplier on how fast the cursor travels between targets. 1 is the
+   * default pace, 2 covers the same ground in half the time. Does not affect
+   * typing speed, click dwell or step delays.
+   */
+  cursorSpeed?: number;
   steps: Step[];
 }
 
@@ -201,5 +207,11 @@ export interface WebreelConfig {
   include?: string[];
   defaultDelay?: number;
   clickDwell?: number;
+  /**
+   * Multiplier on how fast the cursor travels between targets. 1 is the
+   * default pace, 2 covers the same ground in half the time. Does not affect
+   * typing speed, click dwell or step delays.
+   */
+  cursorSpeed?: number;
   videos: VideoConfig[];
 }

--- a/skills/webreel/SKILL.md
+++ b/skills/webreel/SKILL.md
@@ -142,6 +142,7 @@ Config files are auto-discovered as `webreel.config.json` (or `.ts`, `.mts`, `.j
 | `include`      | -           | Array of step file paths prepended to all videos |
 | `defaultDelay` | -           | Default delay (ms) appended after each step      |
 | `clickDwell`   | -           | Cursor dwell time (ms) before a click            |
+| `cursorSpeed`  | `1`         | Multiplier on cursor travel speed                |
 
 ### Per-video fields
 
@@ -160,6 +161,7 @@ Each entry in the `videos` map supports:
 | `sfx`          | inherited      | Override sound effects                             |
 | `defaultDelay` | inherited      | Override default delay                             |
 | `clickDwell`   | inherited      | Override click dwell                               |
+| `cursorSpeed`  | inherited      | Override cursor travel speed                       |
 | `fps`          | `60`           | Frame rate                                         |
 | `quality`      | `80`           | Encoding quality (1-100)                           |
 | `steps`        | required       | Array of step objects                              |


### PR DESCRIPTION
## Summary

Cursor travel is timed from the distance covered (`moveDuration` in `cursor-motion.ts`, and `computeDragTiming` for drags), tuned to feel like a human hand. There is no way to adjust it. On a dense config the cursor spends a lot of the runtime gliding, and the only lever today is speeding up the finished file in post, which speeds up typing and deliberate pauses along with it.

`cursorSpeed` scales the travel duration and nothing else:

```json
{
  "cursorSpeed": 1.75,
  "videos": {
    "hero": {
      "url": "/",
      "cursorSpeed": 1,
      "steps": [{ "action": "click", "text": "Get Started" }]
    }
  }
}
```

`2` covers the same ground in half the time, `0.5` takes twice as long. Typing speed (`charDelay`), click dwell (`clickDwell`) and step delays (`delay` / `defaultDelay`) are unaffected, so the pacing of the demo itself is preserved while dead travel time shrinks. It sits alongside `clickDwell`: settable at the top level, per video, and inherited the same way.

The multiplier lives on `RecordingContext`, so both plain moves and drags pick it up, and the eased path and jitter are unchanged: only the duration scales.

## Test plan

- [x] `pnpm test` (106 core, 112 webreel), `pnpm type-check`, `pnpm lint`, `pnpm format:check`
- [x] New tests: context default and clamping of nonsense values, and drag timing halving at `cursorSpeed: 2`
- [x] Recorded the same 22-step config at three speeds, everything else held constant:

| `cursorSpeed` | output duration |
| --- | --- |
| 1 (default) | 56.9s |
| 1.75 | 38.5s |
| 3 | 29.9s |

  Typing, click dwell and step delays are identical across all three; only travel time changes.

No changeset here, per the release process in AGENTS.md; happy to send one in a follow-up PR.

Generated with [Claude Code](https://claude.com/claude-code)
